### PR TITLE
Corrige link errado e adiciona mais provas de LOAC

### DIFF
--- a/loac/leites/maquinasDeEstados.md
+++ b/loac/leites/maquinasDeEstados.md
@@ -4,4 +4,9 @@
 
 - [Parabrisa](https://i.imgur.com/FeDfDGg.jpg)
 - [Marca Passo](https://i.imgur.com/b92GgEn.jpg)
-- [Ar-Condicionado](https://i.imgur.com/b92GgEn.jpg)
+- [Ar-Condicionado](https://imgur.com/VrWWS6b)
+- [Máquina Copiadora](https://imgur.com/8LHsbRs)
+- [Controle de Cancela](https://imgur.com/JjAFHuw)
+- [Porta de Enrolar](https://imgur.com/cknGnm5)
+- [Fechadura de Cofre](https://imgur.com/cyUiRXd)
+- [Bobina de Papel](https://imgur.com/q8Pjrfo)


### PR DESCRIPTION
Fixes #194 

Esta PR corrige o link errado da questão **Ar Condicionado** no arquivo [_loac/leites/maquinasDeEstados.md_](https://github.com/OpenDevUFCG/Tamburetei/blob/master/loac/leites/maquinasDeEstados.md). Além disso, também adiciona mais leites de LOAC de períodos passados, que são:

- Máquina Copiadora
- Controle de Cancela
- Porta de Enrolar
- Fechadura de Cofre
- Bobina de Papel

---

- [X] Minha contribuição respeita as [regras](https://github.com/OpenDevUFCG/Tamburetei/blob/master/CONTRIBUTING.md#regras) do repositório.
- [X] Minha contribuição respeita as [restrições de upload](https://github.com/OpenDevUFCG/Tamburetei/blob/master/CONTRIBUTING.md#restri%C3%A7%C3%B5es-de-upload) do repositório.
