### PR TITLE
Adiciona plugin pro remark de autolink dos cabeçalhos

### DIFF
--- a/_app/gatsby-config.js
+++ b/_app/gatsby-config.js
@@ -23,7 +23,12 @@ module.exports = {
         name: 'assets',
       },
     },
-    'gatsby-transformer-remark',
+    {
+      resolve: 'gatsby-transformer-remark',
+      options: {
+        plugins: ['gatsby-remark-autolink-headers'],
+      },
+    },
     'gatsby-transformer-sharp',
     'gatsby-plugin-sharp',
     {

--- a/_app/package.json
+++ b/_app/package.json
@@ -27,6 +27,7 @@
     "gatsby-plugin-react-helmet": "^3.1.10",
     "gatsby-plugin-sass": "^2.1.17",
     "gatsby-plugin-sharp": "^2.2.27",
+    "gatsby-remark-autolink-headers": "^2.1.13",
     "gatsby-source-filesystem": "^2.1.28",
     "gatsby-transformer-sharp": "^2.2.19",
     "node-sass": "^4.12.0",

--- a/_app/yarn.lock
+++ b/_app/yarn.lock
@@ -5462,6 +5462,17 @@ gatsby-react-router-scroll@^2.1.11:
     scroll-behavior "^0.9.10"
     warning "^3.0.0"
 
+gatsby-remark-autolink-headers@^2.1.13:
+  version "2.1.13"
+  resolved "https://registry.yarnpkg.com/gatsby-remark-autolink-headers/-/gatsby-remark-autolink-headers-2.1.13.tgz#f707e6d5ab063aae368604edfae0c948e8154884"
+  integrity sha512-DQnb1eLfMFX5QXn2LDV/eu587dEBrjKuVB+Pt1Q3cVr3BpyFHjDiDYxMgGfgNJ5L1omB3DFHiuBrUmng6XJtWA==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    github-slugger "^1.2.1"
+    lodash "^4.17.15"
+    mdast-util-to-string "^1.0.6"
+    unist-util-visit "^1.4.1"
+
 gatsby-source-filesystem@^2.1.28:
   version "2.1.28"
   resolved "https://registry.yarnpkg.com/gatsby-source-filesystem/-/gatsby-source-filesystem-2.1.28.tgz#c438306f4906564f3bf62464bc7240b571634e01"
@@ -5783,7 +5794,7 @@ github-from-package@0.0.0:
   resolved "https://registry.yarnpkg.com/github-from-package/-/github-from-package-0.0.0.tgz#97fb5d96bfde8973313f20e8288ef9a167fa64ce"
   integrity sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=
 
-github-slugger@^1.1.1:
+github-slugger@^1.1.1, github-slugger@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/github-slugger/-/github-slugger-1.2.1.tgz#47e904e70bf2dccd0014748142d31126cfd49508"
   integrity sha512-SsZUjg/P03KPzQBt7OxJPasGw6NRO5uOgiZ5RGXVud5iSIZ0eNZeNp5rTwCxtavrRUa/A77j8mePVc5lEvk0KQ==


### PR DESCRIPTION
Este PR adiciona o plugin `gatsby-remark-autolink-headers` para adicionar automaticamente um `id` nos cabeçalhos da página. Conserta um bug que pode ser visto na página de [extras de programação 1](https://tamburetei.opendevufcg.org/prog1/extras/), onde os links do sumário não funcionam.