### PR TITLE
Muda links de conteúdo de http para https

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ e esse projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/spec/
 ### Modificado
 - Tutoriais de Python em Programação I agora utilizam Python 3.5+.
 
+### Corrigido
+
+- Referências de conteúdo HTTP para HTTPS.
+
 
 ## [1.0.3] - 28/09/2019
 

--- a/calculo1/linksUteis.md
+++ b/calculo1/linksUteis.md
@@ -26,14 +26,14 @@ Uma lista de links que irão auxiliá-lo no estudo da disciplina.
 ## Ferramentas
 
 - [Symbolab](https://www.symbolab.com/)
-- [Wolfram Alpha](http://www.wolframalpha.com/)
+- [Wolfram Alpha](https://www.wolframalpha.com/)
 - [Desmos](https://www.desmos.com/calculator)
 - [Geogebra](https://www.geogebra.org/graphing)
 
 ## Fóruns
 
-- [Math Stack Exchange](http://math.stackexchange.com/)
-- [Math Overflow](http://mathoverflow.net/)
+- [Math Stack Exchange](https://math.stackexchange.com/)
+- [Math Overflow](https://mathoverflow.net/)
 - [AoPS Online](https://artofproblemsolving.com/community)
 
 ## Blogs

--- a/es/resumos/scrum.md
+++ b/es/resumos/scrum.md
@@ -16,7 +16,7 @@
 
 Scrum é uma metodologia ágil, desenvolvida no intuito de ser um framework para gestão e planejamento de projetos de software. Também é considerado uma das melhores práticas de desenvolvimento ágil da atualidade.
 
-![Esquematização do Scrum](http://www.desenvolvimentoagil.com.br/images/scrum/ciclo_scrum.gif)
+![Esquematização do Scrum](https://www.desenvolvimentoagil.com.br/images/scrum/ciclo_scrum.gif)
 
 Agora, serão apresentados alguns conceitos importantes do Scrum:
 

--- a/fmcc2/leites/exerciciosResolvidos/primeiroEstagio.md
+++ b/fmcc2/leites/exerciciosResolvidos/primeiroEstagio.md
@@ -6,26 +6,26 @@ Mostre que se *x* ou *y* forem inteiros pares, então *xy* é par.
 - **i)** Temos que um número par *n* pode ser descrito como *n = 2k*, e um número ímpar *t* como *t = 2w + 1*;
 - **ii)** Temos que: *x = 2k* e *y = 2w + 1*, então:
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Clarge%20xy%20%3D%202k%282w%20&plus;%201%29">
+  <img src="https://latex.codecogs.com/gif.latex?%5Clarge%20xy%20%3D%202k%282w%20&plus;%201%29">
 </p>
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Clarge%20xy%20%3D%204kw%20&plus;%202k">
+  <img src="https://latex.codecogs.com/gif.latex?%5Clarge%20xy%20%3D%204kw%20&plus;%202k">
 </p>
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Clarge%20xy%20%3D%202%28kw%20&plus;%20k%29">
+  <img src="https://latex.codecogs.com/gif.latex?%5Clarge%20xy%20%3D%202%28kw%20&plus;%20k%29">
 </p>
 <br/>
 
 - **iii)** Como a multiplicação e a soma entre inteiros resulta em um outro inteiro, então a afirmação se torna verdadeira;
 - **iv)** Da mesma forma do item **i)**, temos que: *x = 2k + 1* e *y = 2w*, então:
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Clarge%20xy%20%3D%20%282k%20&plus;%201%29%282w%29">
+  <img src="https://latex.codecogs.com/gif.latex?%5Clarge%20xy%20%3D%20%282k%20&plus;%201%29%282w%29">
 </p>
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Clarge%20xy%20%3D%204kw%20&plus;%202w">
+  <img src="https://latex.codecogs.com/gif.latex?%5Clarge%20xy%20%3D%204kw%20&plus;%202w">
 </p>
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Clarge%20xy%20%3D%202%282kw%20&plus;%20w%29">
+  <img src="https://latex.codecogs.com/gif.latex?%5Clarge%20xy%20%3D%202%282kw%20&plus;%20w%29">
 </p>
 <br/>
 
@@ -37,7 +37,7 @@ Dê uma demonstração direta ao teorema *"Se um inteiro é divisível por 6, en
 - **i)** Como *n|6*, temos que *n = 6k*, para *k* inteiro;
 - **ii)** Atribuindo a condição do enunciado em ambos os lados da equação, temos:
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Clarge%20%5Cfrac%7B2n%7D%7B4%7D%20%3D%20%5Cfrac%7B2%286k%29%7D%7B4%7D%20%3D%203k">
+  <img src="https://latex.codecogs.com/gif.latex?%5Clarge%20%5Cfrac%7B2n%7D%7B4%7D%20%3D%20%5Cfrac%7B2%286k%29%7D%7B4%7D%20%3D%203k">
 </p>
 <br/>
 
@@ -46,7 +46,7 @@ Dê uma demonstração direta ao teorema *"Se um inteiro é divisível por 6, en
 ## Questão 3 (Demonstração por contraposição)
 Prove que o número *n* é um inteiro ímpar se, e somente se, 
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Clarge%203n%20&plus;%205%20%3D%206k%20&plus;%208">
+  <img src="https://latex.codecogs.com/gif.latex?%5Clarge%203n%20&plus;%205%20%3D%206k%20&plus;%208">
 </p>
 <br/>
 
@@ -57,43 +57,43 @@ para algum inteiro *k*.
   - *Se 3n + 5 = 6k + 8 para algum inteiro k, então n é um inteiro ímpar*.
 - **ii)** Podemos provar o primeiro caso por demosntração direta, substituindo *n*:
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Clarge%203%282k%20&plus;%201%29%20&plus;%205%20%3D%206k%20&plus;%208">
+  <img src="https://latex.codecogs.com/gif.latex?%5Clarge%203%282k%20&plus;%201%29%20&plus;%205%20%3D%206k%20&plus;%208">
 </p>
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Clarge%206k%20&plus;%208%20%3D%206k%20&plus;%208">
+  <img src="https://latex.codecogs.com/gif.latex?%5Clarge%206k%20&plus;%208%20%3D%206k%20&plus;%208">
 </p>
 
 - **iii)** Na segunda condição, temos que:
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Clarge%20P%3A3n&plus;5%20%3D6k%20&plus;%208">
+  <img src="https://latex.codecogs.com/gif.latex?%5Clarge%20P%3A3n&plus;5%20%3D6k%20&plus;%208">
 </p>
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Clarge%20Q%3A%20%5Ctextrm%7Bn%20eh%20impar%7D">
+  <img src="https://latex.codecogs.com/gif.latex?%5Clarge%20Q%3A%20%5Ctextrm%7Bn%20eh%20impar%7D">
 </p>
 
 - **iv)** Por contraposição, temos:
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Clarge%20P%5Crightarrow%20Q%5Cequiv%20%5Cneg%20Q%20%5Crightarrow%20%5Cneg%20P">
+  <img src="https://latex.codecogs.com/gif.latex?%5Clarge%20P%5Crightarrow%20Q%5Cequiv%20%5Cneg%20Q%20%5Crightarrow%20%5Cneg%20P">
 </p>
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Clarge%20%5Cneg%20Q%3A%20%5Ctextrm%7Bn%20eh%20par%7D">
+  <img src="https://latex.codecogs.com/gif.latex?%5Clarge%20%5Cneg%20Q%3A%20%5Ctextrm%7Bn%20eh%20par%7D">
 </p>
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Clarge%20%5Cneg%20P%3A%203n&plus;5%5Cneq%206k%20&plus;%208">
+  <img src="https://latex.codecogs.com/gif.latex?%5Clarge%20%5Cneg%20P%3A%203n&plus;5%5Cneq%206k%20&plus;%208">
 </p>
 
 - **v)** Substituindo n, temos:
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Clarge%203%282k%29&plus;5%20%5Cneq%206k%20&plus;%208%20%5CRightarrow%206k%20&plus;%205%20%5Cneq%206k%20&plus;%208">
+  <img src="https://latex.codecogs.com/gif.latex?%5Clarge%203%282k%29&plus;5%20%5Cneq%206k%20&plus;%208%20%5CRightarrow%206k%20&plus;%205%20%5Cneq%206k%20&plus;%208">
 </p>
 
 
 - **vi)** Portanto, por contraposição, demonstra-se a segunda condição, verificando-se o teorema.
 
 ## Questão 4 (Demonstração por contradição)
-Mostre por absurdo que <img src="http://latex.codecogs.com/gif.latex?%5Cinline%20%5Csqrt%7B2%7D"> é um número irracional.
+Mostre por absurdo que <img src="https://latex.codecogs.com/gif.latex?%5Cinline%20%5Csqrt%7B2%7D"> é um número irracional.
 
-- **i)** Vamos supor que <img src="http://latex.codecogs.com/gif.latex?%5Cinline%20%5Csqrt%7B2%7D"> seja um número racional;
+- **i)** Vamos supor que <img src="https://latex.codecogs.com/gif.latex?%5Cinline%20%5Csqrt%7B2%7D"> seja um número racional;
 - **ii)** Um número racional é um número que pode ser escrito na forma *a/b*, sendo *a* um inteiro e *b* um inteiro diferente de 0;
 - **iii)** Suponhamos que <img src="https://latex.codecogs.com/gif.latex?%5Cinline%20%5Csqrt%7B2%7D%20%3D%20%5Cfrac%7Ba%7D%7Bb%7D">;
 - **iv)** Então, *a* e *b*, não podem ser ambos pares, pois se fossem, daria para simplificar;
@@ -125,36 +125,36 @@ Mostrar para todo inteiro positivo *n*,
 
 - **Passo 1:** Para demonstrar o caso base , vamos usar *n = 1*, assim temos:
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Clarge%20%5Cfrac%7B1%281%20&plus;%201%29%7D%7B2%7D%20%3D%20%5Cfrac%7B2%7D%7B2%7D%20%3D%201">
+  <img src="https://latex.codecogs.com/gif.latex?%5Clarge%20%5Cfrac%7B1%281%20&plus;%201%29%7D%7B2%7D%20%3D%20%5Cfrac%7B2%7D%7B2%7D%20%3D%201">
 </p>
 
 Para o caso base, a afirmação é verdadeira.
 
 - **Passo 2:** Na hipótese indutiva, tomaremos a afirmação para *n = k* como verdadeira, ou seja:
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Clarge%201%20&plus;%202%20&plus;%20...%20&plus;%20k%20%3D%20%5Cfrac%7Bk%28k&plus;1%29%7D%7B2%7D">
+  <img src="https://latex.codecogs.com/gif.latex?%5Clarge%201%20&plus;%202%20&plus;%20...%20&plus;%20k%20%3D%20%5Cfrac%7Bk%28k&plus;1%29%7D%7B2%7D">
 </p>
 
 - **Passo 3:** Deve-se mostrar, para *n = k +1*, que
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Clarge%201%20&plus;%202%20&plus;%20...%20&plus;%20k%20&plus;%20%28k%20&plus;%201%29%20%3D%20%5Cfrac%7B%28k&plus;1%29%28%28k&plus;1%29&plus;1%29%7D%7B2%7D">
+  <img src="https://latex.codecogs.com/gif.latex?%5Clarge%201%20&plus;%202%20&plus;%20...%20&plus;%20k%20&plus;%20%28k%20&plus;%201%29%20%3D%20%5Cfrac%7B%28k&plus;1%29%28%28k&plus;1%29&plus;1%29%7D%7B2%7D">
 </p>
 
 é verdadeira.
 
 **i)** Utilizando a conjectura fornecida no passo **ii)**, temos que:
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Clarge%20%5Cfrac%7Bk%28k&plus;1%29%7D%7B2%7D%20&plus;%20k%28k&plus;1%29%20%3D%20%5Cfrac%7B%28k&plus;1%29%28k&plus;1&plus;1%29%7D%7B2%7D">
+  <img src="https://latex.codecogs.com/gif.latex?%5Clarge%20%5Cfrac%7Bk%28k&plus;1%29%7D%7B2%7D%20&plus;%20k%28k&plus;1%29%20%3D%20%5Cfrac%7B%28k&plus;1%29%28k&plus;1&plus;1%29%7D%7B2%7D">
 </p>
 
 **ii)** Tornando os membros com o mesmo denominador na primeira parte da igualdade, temos que
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Clarge%20%5Cfrac%7Bk%28k&plus;1%29%20&plus;%202%28k&plus;1%29%7D%7B2%7D%20%3D%20%5Cfrac%7B%28k&plus;1%29%28k&plus;2%29%7D%7B2%7D">
+  <img src="https://latex.codecogs.com/gif.latex?%5Clarge%20%5Cfrac%7Bk%28k&plus;1%29%20&plus;%202%28k&plus;1%29%7D%7B2%7D%20%3D%20%5Cfrac%7B%28k&plus;1%29%28k&plus;2%29%7D%7B2%7D">
 </p>
 
 **iii)** Aplicando a distributiva entre os elementos em ambas as partes, temos que:
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Clarge%20%5Cfrac%7Bk%5E%7B2%7D%20&plus;%20k%20&plus;%202k%20&plus;%202%7D%7B2%7D%20%3D%20%5Cfrac%7Bk%5E%7B2%7D%20&plus;%20k%20&plus;%202k%20&plus;%202%7D%7B2%7D">
+  <img src="https://latex.codecogs.com/gif.latex?%5Clarge%20%5Cfrac%7Bk%5E%7B2%7D%20&plus;%20k%20&plus;%202k%20&plus;%202%7D%7B2%7D%20%3D%20%5Cfrac%7Bk%5E%7B2%7D%20&plus;%20k%20&plus;%202k%20&plus;%202%7D%7B2%7D">
 </p>
 
 **iv)** Como demonstramos a veracidade da afirmação inicial para *n = k +1*, concluímos o **Passo 3** e provamos por indução a integridade desta mesma.
@@ -165,26 +165,26 @@ Prove que para todo a, b, c inteiros, se a|b e a|c então a|(b+c)
 
 - **i)** Temos por definição que:
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Clarge%20a%7Cb%20%5CRightarrow%20b%20%3D%20a.x%2C%20x%20%5Cin%20%5Cmathbb%7BZ%7D">
+  <img src="https://latex.codecogs.com/gif.latex?%5Clarge%20a%7Cb%20%5CRightarrow%20b%20%3D%20a.x%2C%20x%20%5Cin%20%5Cmathbb%7BZ%7D">
 </p>
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Clarge%20a%7Cc%20%5CRightarrow%20c%20%3D%20a.t%2C%20t%20%5Cin%20%5Cmathbb%7BZ%7D">
+  <img src="https://latex.codecogs.com/gif.latex?%5Clarge%20a%7Cc%20%5CRightarrow%20c%20%3D%20a.t%2C%20t%20%5Cin%20%5Cmathbb%7BZ%7D">
 </p>
 
 - **ii)** Seguindo a lógica do passo **i)**, temos que:
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Clarge%20a%7C%28b&plus;c%29%20%5CRightarrow%20b&plus;c%20%3D%20a.z%2C%20z%20%5Cin%20%5Cmathbb%7BZ%7D">
+  <img src="https://latex.codecogs.com/gif.latex?%5Clarge%20a%7C%28b&plus;c%29%20%5CRightarrow%20b&plus;c%20%3D%20a.z%2C%20z%20%5Cin%20%5Cmathbb%7BZ%7D">
 </p>
 
 - **iii)** Substituindo os valores do passo **i)**:
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Clarge%20b%20&plus;%20c%20%3D%20a.x%20&plus;%20a.t%20%3D%20a.z">
+  <img src="https://latex.codecogs.com/gif.latex?%5Clarge%20b%20&plus;%20c%20%3D%20a.x%20&plus;%20a.t%20%3D%20a.z">
 </p>
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Clarge%20a.%28x&plus;t%29%20%3D%20a.z">
+  <img src="https://latex.codecogs.com/gif.latex?%5Clarge%20a.%28x&plus;t%29%20%3D%20a.z">
 </p>
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Clarge%20x&plus;t%20%3D%20z">
+  <img src="https://latex.codecogs.com/gif.latex?%5Clarge%20x&plus;t%20%3D%20z">
 </p>
 
 - **iv)** Por definição, como a soma de dois inteiros resulta em um inteiro, então prova-se por demonstração direta que se a|b e a|c então a|(b+c).
@@ -194,16 +194,16 @@ Prove, usando indução forte, que é possível pagar qualquer quantia (inteira)
 
 - **Passo base:** Para *P(8)*, *P(9)*, *P(10)*, *P(11)*, temos que:
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Clarge%20P%288%29%20%3D%205%20&plus;%203%20%3D%208">
+  <img src="https://latex.codecogs.com/gif.latex?%5Clarge%20P%288%29%20%3D%205%20&plus;%203%20%3D%208">
 </p>
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Clarge%20P%289%29%20%3D%203%20&plus;%203%20&plus;%203%20%3D%209">
+  <img src="https://latex.codecogs.com/gif.latex?%5Clarge%20P%289%29%20%3D%203%20&plus;%203%20&plus;%203%20%3D%209">
 </p>
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Clarge%20P%2810%29%20%3D%205%20&plus;%205%20%3D%2010">
+  <img src="https://latex.codecogs.com/gif.latex?%5Clarge%20P%2810%29%20%3D%205%20&plus;%205%20%3D%2010">
 </p>
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Clarge%20P%2811%29%20%3D%203%20&plus;%203%20&plus;%205%20%3D%2011">
+  <img src="https://latex.codecogs.com/gif.latex?%5Clarge%20P%2811%29%20%3D%203%20&plus;%203%20&plus;%205%20%3D%2011">
 </p>
 
 ou seja, para o caso base, a afirmação é verdadeira;
@@ -218,45 +218,45 @@ Mostre que uma árvore binária completa de *k* níveis possui *2^k - 1* vértic
 
 - **Passo 1:** Para demonstrar o caso base, vamos usar *k = 1*, assim temos:
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Clarge%202%5E%7B1%7D%20-1%20%3D%201">
+  <img src="https://latex.codecogs.com/gif.latex?%5Clarge%202%5E%7B1%7D%20-1%20%3D%201">
 </p>
 
 Para o caso base, a afirmação é verdadeira.
 
 - **Passo 2:** Na hipótese indutiva, tomaremos a afirmação para *k = a* como verdadeira, ou seja: 
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Clarge%20%5Csum_%7Bi%20%3D1%7D%5E%7Ba%7D%202%5E%7Bi%20-1%7D%20-%201%20%3D%202%5E%7Ba%7D%20-%201">
+  <img src="https://latex.codecogs.com/gif.latex?%5Clarge%20%5Csum_%7Bi%20%3D1%7D%5E%7Ba%7D%202%5E%7Bi%20-1%7D%20-%201%20%3D%202%5E%7Ba%7D%20-%201">
 </p>
 
 onde a primeira parte da igualdade representa a sequência natural de uma árvore binária completa.
 
-- **Passo 3:** Deve-se mostrar que o somatório de vértices dos *a + 1* níveis é igual a <img src="http://latex.codecogs.com/gif.latex?%5Cinline%202%5E%7Ba%20&plus;1%7D%20-%201">.
+- **Passo 3:** Deve-se mostrar que o somatório de vértices dos *a + 1* níveis é igual a <img src="https://latex.codecogs.com/gif.latex?%5Cinline%202%5E%7Ba%20&plus;1%7D%20-%201">.
 
 **i)** Temos que a soma dos vértices entre os *a + 1* níveis, será dado pelo somatório fornecido pela conjectura apresentada no **Passo 2** adicionado pelo próximo elemento da sequência, que será o somatório do nível *a + 1*.
 
 **ii)** Ou seja:
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Clarge%20%5Csum_%7Bi%3D1%7D%5E%7Ba&plus;1%7D%20%3D%202%5E%7Bi-1%7D%20%3D%202%5E%7Ba%7D%20-%201%20&plus;%202%5E%7B%28a&plus;1%29%20-1%7D%20%3D%202%5E%7Ba%20&plus;%201%7D%20-1">
+  <img src="https://latex.codecogs.com/gif.latex?%5Clarge%20%5Csum_%7Bi%3D1%7D%5E%7Ba&plus;1%7D%20%3D%202%5E%7Bi-1%7D%20%3D%202%5E%7Ba%7D%20-%201%20&plus;%202%5E%7B%28a&plus;1%29%20-1%7D%20%3D%202%5E%7Ba%20&plus;%201%7D%20-1">
 </p>
 
 **iii)** Manipulando a segunda e terceira parte da igualdade, temos: 
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Clarge%202%5E%7Ba%7D%20-%201%20&plus;%202%5E%7B%28a&plus;1%29%20-1%7D%20%3D%202%5E%7Ba%20&plus;%201%7D%20-1">
+  <img src="https://latex.codecogs.com/gif.latex?%5Clarge%202%5E%7Ba%7D%20-%201%20&plus;%202%5E%7B%28a&plus;1%29%20-1%7D%20%3D%202%5E%7Ba%20&plus;%201%7D%20-1">
 </p>
 
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Clarge%202%5E%7Ba%7D%20-%201%20&plus;%202%5E%7Ba%7D%20%3D%202%5E%7Ba%20&plus;%201%7D%20-1">
+  <img src="https://latex.codecogs.com/gif.latex?%5Clarge%202%5E%7Ba%7D%20-%201%20&plus;%202%5E%7Ba%7D%20%3D%202%5E%7Ba%20&plus;%201%7D%20-1">
 </p>
 
 **iv)** Sabendo, por definição que *x + x = 2x*, temos:
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Clarge%202%282%5E%7Ba%7D%29%20-%201%20%3D%202%5E%7Ba&plus;1%7D%20-%201">
+  <img src="https://latex.codecogs.com/gif.latex?%5Clarge%202%282%5E%7Ba%7D%29%20-%201%20%3D%202%5E%7Ba&plus;1%7D%20-%201">
 </p>
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Clarge%202%5E%7B1%7D.%282%5E%7Ba%7D%29%20-%201%20%3D%202%5E%7Ba&plus;1%7D%20-%201">
+  <img src="https://latex.codecogs.com/gif.latex?%5Clarge%202%5E%7B1%7D.%282%5E%7Ba%7D%29%20-%201%20%3D%202%5E%7Ba&plus;1%7D%20-%201">
 </p>
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Clarge%202%5E%7Ba&plus;1%7D%20-%201%20%3D%202%5E%7Ba&plus;1%7D%20-%201">
+  <img src="https://latex.codecogs.com/gif.latex?%5Clarge%202%5E%7Ba&plus;1%7D%20-%201%20%3D%202%5E%7Ba&plus;1%7D%20-%201">
 </p>
 
 **v)** Como demonstramos a veracidade da afirmação inicial para *k = a + 1*, concluímos o passo 3, e provamos por indução a integridade desta mesma.

--- a/fmcc2/resumos/README.md
+++ b/fmcc2/resumos/README.md
@@ -1,0 +1,6 @@
+---
+title: Resumos FMCC2
+---
+
+- [Primeiro estágio](primeiroEstagio.md)
+- [Quinto estágio](quintoEstagio.md)

--- a/fmcc2/resumos/primeiroEstagio.md
+++ b/fmcc2/resumos/primeiroEstagio.md
@@ -11,20 +11,20 @@
 
 ## Formas dos Teoremas:
 
-- Muitos teoremas são apresentados na forma condicional <img src="http://latex.codecogs.com/gif.latex?%5Cinline%20p%20%5Crightarrow%20q">.
+- Muitos teoremas são apresentados na forma condicional <img src="https://latex.codecogs.com/gif.latex?%5Cinline%20p%20%5Crightarrow%20q">.
 - **Exemplo 1:** "se x > y, no qual x e y são números reais positivos, então x² > y²". O que esse teorema realmente significa é:
 
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Clarge%20%5Cforall_%7Bx%2Cy%7D%28P%28x%2Cy%29%5Crightarrow%20Q%28x%2Cy%29%29">
+  <img src="https://latex.codecogs.com/gif.latex?%5Clarge%20%5Cforall_%7Bx%2Cy%7D%28P%28x%2Cy%29%5Crightarrow%20Q%28x%2Cy%29%29">
 </p>
 
 onde,
 
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Clarge%20P%28x%2Cy%29%20%5Ctherefore%20x%20%3E%20y">
+  <img src="https://latex.codecogs.com/gif.latex?%5Clarge%20P%28x%2Cy%29%20%5Ctherefore%20x%20%3E%20y">
 </p>
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Clarge%20Q%28x%2Cy%29%20%5Ctherefore%20x%5E2%20%3E%20y%5E2">
+  <img src="https://latex.codecogs.com/gif.latex?%5Clarge%20Q%28x%2Cy%29%20%5Ctherefore%20x%5E2%20%3E%20y%5E2">
 </p>
 
 - Teoremas também aparecem na forma condicional.
@@ -35,13 +35,13 @@ onde,
 - Considere as definições a seguir para os exemplos que seguem:
   - **Paridade de números inteiros:** um inteiro **n** é par se existe um inteiro **k** tal que *n = 2k*, e **n** é ímpar se existe um inteiro **k** tal que *n = 2k + 1*.
   - **Números racionais:** um número real **r** é dito racional se existem inteiros *p* e *q*, com *q* diferente de 0, tal que *r = p/q*.
-  - **Potência perfeita:** um número inteiro **n** é dito uma potência perfeita se existem números inteiros *b > 1* e *k > 1* tais que <img src="http://latex.codecogs.com/gif.latex?%5Cinline%20n%20%3D%20b%5E%7Bk%7D">.
+  - **Potência perfeita:** um número inteiro **n** é dito uma potência perfeita se existem números inteiros *b > 1* e *k > 1* tais que <img src="https://latex.codecogs.com/gif.latex?%5Cinline%20n%20%3D%20b%5E%7Bk%7D">.
   
 ## Demonstração exaustiva e por Contra-exemplo
 
 - Verifica-se a verdade da conjectura para todos os elementos da coleção.
 - Para provar a falsidade da conjectura, basta achar um contra-exemplo.
-- **Exemplo 2:** Prove a conjectura *"Para todo inteiro positivo* <img src="http://latex.codecogs.com/gif.latex?%5Cinline%20n%2C%20n%21%20%5Cleq%20n%5E2">*"*.
+- **Exemplo 2:** Prove a conjectura *"Para todo inteiro positivo* <img src="https://latex.codecogs.com/gif.latex?%5Cinline%20n%2C%20n%21%20%5Cleq%20n%5E2">*"*.
   - **Solução:** a conjectura é **falsa** pois não é verdade para todo *n*: é falsa para *n = 4*.
   
 ## Demonstração por casos:
@@ -54,37 +54,37 @@ onde,
 
 ## Demonstração direta
 
-- A demosntração direta de uma afirmação da forma <img src="http://latex.codecogs.com/gif.latex?%5Cinline%20p%20%5Crightarrow%20q">:
+- A demosntração direta de uma afirmação da forma <img src="https://latex.codecogs.com/gif.latex?%5Cinline%20p%20%5Crightarrow%20q">:
   - **i)** assume que o antecedente *p* é verdadeiro e daí;
   - **ii)** deduz a conclusão *q*.
 - Normalmente usa-se axiomas, definições, lemmas e teoremas, em conjuntos com regras de inferência, para mostrar que *q* também deve ser verdade.
 
 - **Exemplo 4:** Prove o seguinte teorema: *se n é um número ímpar, então n² também é ímpar".
-  - **i)** Como *n* é ímpar, *n = 2k + 1*, para <img src="http://latex.codecogs.com/gif.latex?%5Cinline%20k%5Cin%20%5Cmathbb%7BZ%7D">;
+  - **i)** Como *n* é ímpar, *n = 2k + 1*, para <img src="https://latex.codecogs.com/gif.latex?%5Cinline%20k%5Cin%20%5Cmathbb%7BZ%7D">;
   - **ii)** Elevando os dois lados da igualdade ao quadrado, *n² = (2k + 1)²*, temos:
   <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Clarge%20n%5E%7B2%7D%20%3D%204k%5E%7B2%7D%20&plus;%204k%20&plus;%201">
+  <img src="https://latex.codecogs.com/gif.latex?%5Clarge%20n%5E%7B2%7D%20%3D%204k%5E%7B2%7D%20&plus;%204k%20&plus;%201">
 </p>
 
 rearranjando,
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Clarge%20n%5E%7B2%7D%20%3D%202%282k%5E%7B2%7D%20&plus;%202k%29%20&plus;%201">
+  <img src="https://latex.codecogs.com/gif.latex?%5Clarge%20n%5E%7B2%7D%20%3D%202%282k%5E%7B2%7D%20&plus;%202k%29%20&plus;%201">
 </p>
 
 portanto, concluímos que *n²* também é ímpar.
 
 ## Demonstração por contraposição
 
-- Uma conjectura da forma <img src="http://latex.codecogs.com/gif.latex?%5Cinline%20p%20%5Crightarrow%20q"> pode ser provada mostrando-se a sua contrapostiva:
+- Uma conjectura da forma <img src="https://latex.codecogs.com/gif.latex?%5Cinline%20p%20%5Crightarrow%20q"> pode ser provada mostrando-se a sua contrapostiva:
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Clarge%20%5Cneg%20q%20%5Crightarrow%20%5Cneg%20p">
+  <img src="https://latex.codecogs.com/gif.latex?%5Clarge%20%5Cneg%20q%20%5Crightarrow%20%5Cneg%20p">
 </p>
 
 - **Exemplo 5:** Mostre que se *3n + 2* é ímpar, então *n* é ímpar.
   - **i)** Primeiro assumimos que *n* é par (*a negação que n é ímpar*), ou seja, *n = 2k*;
   - **i)** Agora basta verificar que *3n + 2* também é par:
   <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Clarge%203%282k%29%20&plus;%202%20%3D%206k%20&plus;%202%20%3D%202%283k%20&plus;%201%29">
+  <img src="https://latex.codecogs.com/gif.latex?%5Clarge%203%282k%29%20&plus;%202%20%3D%206k%20&plus;%202%20%3D%202%283k%20&plus;%201%29">
 </p>
 
   portanto, demonstra-se por contraposição que a afirmativa é verdadeira.
@@ -93,7 +93,7 @@ portanto, concluímos que *n²* também é ímpar.
 ## Demonstração por contradição
 
 - Para demonstrar *p*, assumimos *¬p* e mostramos que isso leva a uma contradição;
-- Para provar <img src="http://latex.codecogs.com/gif.latex?%5Cinline%20p%20%5Crightarrow%20q">, bastar mostrar <img src="http://latex.codecogs.com/gif.latex?%5Cinline%20p%20%5Cwedge%20q%20%5Crightarrow%20F">.
+- Para provar <img src="https://latex.codecogs.com/gif.latex?%5Cinline%20p%20%5Crightarrow%20q">, bastar mostrar <img src="https://latex.codecogs.com/gif.latex?%5Cinline%20p%20%5Cwedge%20q%20%5Crightarrow%20F">.
 - **Exemplo 6:** Mostre que se *3n + 2* é ímpar, então *n* é ímpar por contradição.
   - **i)** Vamos assumir que *3n + 2* é ímpar e *n* é par;
   - **ii)** Vimos que no *exemplo 5* que se *n* é par, então *3n + 2* é par;
@@ -102,44 +102,44 @@ portanto, concluímos que *n²* também é ímpar.
 ## Indução Matemática
 
 - É usada para mostrar que uma dada afirmação é verdadeira para todos os inteiros positivos.
-- Por exemplo, para todo <img src="http://latex.codecogs.com/gif.latex?%5Cinline%20n%20%5Cin%20%5Cmathbb%7BZ%7D%5E%7B&plus;%7D">:
-  - <img src="http://latex.codecogs.com/gif.latex?%5Cinline%20n%21%20%5Cleq%20n%5E%7Bn%7D">;
-  - <img src="http://latex.codecogs.com/gif.latex?%5Cinline%20n%5E%7B3%7D%20-%20n"> é divisível por 3;
-  - a soma dos primeiros *n* inteiros positivos é <img src="http://latex.codecogs.com/gif.latex?%5Cinline%20%5Cfrac%7Bn%28n&plus;1%29%7D%7B2%7D">.
+- Por exemplo, para todo <img src="https://latex.codecogs.com/gif.latex?%5Cinline%20n%20%5Cin%20%5Cmathbb%7BZ%7D%5E%7B&plus;%7D">:
+  - <img src="https://latex.codecogs.com/gif.latex?%5Cinline%20n%21%20%5Cleq%20n%5E%7Bn%7D">;
+  - <img src="https://latex.codecogs.com/gif.latex?%5Cinline%20n%5E%7B3%7D%20-%20n"> é divisível por 3;
+  - a soma dos primeiros *n* inteiros positivos é <img src="https://latex.codecogs.com/gif.latex?%5Cinline%20%5Cfrac%7Bn%28n&plus;1%29%7D%7B2%7D">.
   
 ## Indução fraca
 
-- Primeiro princípio da indução: Para provar que *P(n)* é verdade para todo <img src="http://latex.codecogs.com/gif.latex?%5Cinline%20n%20%5Cin%20%5Cmathbb%7BZ%7D%5E%7B&plus;%7D">, precisaremos provar o seguinte:
+- Primeiro princípio da indução: Para provar que *P(n)* é verdade para todo <img src="https://latex.codecogs.com/gif.latex?%5Cinline%20n%20%5Cin%20%5Cmathbb%7BZ%7D%5E%7B&plus;%7D">, precisaremos provar o seguinte:
   - *P(1)* (Passo básico ou base da indução);
-  - <img src="http://latex.codecogs.com/gif.latex?%5Cinline%20%28%5Cforall_%7Bk%7D%20%5Cin%20%5Cmathbb%7BZ%7D%5E%7B&plus;%7D%29%28P%28k%29%20%5Crightarrow%20P%28k&plus;1%29%29"> (Passo indutivo).
+  - <img src="https://latex.codecogs.com/gif.latex?%5Cinline%20%28%5Cforall_%7Bk%7D%20%5Cin%20%5Cmathbb%7BZ%7D%5E%7B&plus;%7D%29%28P%28k%29%20%5Crightarrow%20P%28k&plus;1%29%29"> (Passo indutivo).
   
 - Demonstração usando o primeiro princípio da indução:
   - **i)** Prove a base da indução;
   - **ii)** Suponha *P(k)*;
   - **iii)** Prove *P(k + 1)*.
   
-- **Exemplo 7:** Mostre que a equação *1 + 3 + 5 + ... + (2n - 1) = n²* é verdadeira para todo  <img src="http://latex.codecogs.com/gif.latex?%5Cinline%20n%20%5Cin%20%5Cmathbb%7BZ%7D%5E%7B&plus;%7D">.
+- **Exemplo 7:** Mostre que a equação *1 + 3 + 5 + ... + (2n - 1) = n²* é verdadeira para todo  <img src="https://latex.codecogs.com/gif.latex?%5Cinline%20n%20%5Cin%20%5Cmathbb%7BZ%7D%5E%7B&plus;%7D">.
 - **i)** Para *n = 1*, *1 = 1²* é verdadeiro. Agora supomos *P(k)* verdadeiro:
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Clarge%201%20&plus;%203%20&plus;%205%20&plus;%20...&plus;%20%282k%20-1%29%20%3D%20k%5E%7B2%7D">
+  <img src="https://latex.codecogs.com/gif.latex?%5Clarge%201%20&plus;%203%20&plus;%205%20&plus;%20...&plus;%20%282k%20-1%29%20%3D%20k%5E%7B2%7D">
 </p>
 <br/>
 
 - **ii)** Usando a hipótese da indução, queremos mostrar *P(k + 1)*, ou seja:
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Clarge%201%20&plus;%203%20&plus;%205%20&plus;%20...&plus;%20%282k%20-%201%29&plus;%20%282%28k&plus;1%29%20-1%29%20%3D%20%28k&plus;1%29%5E%7B2%7D">
+  <img src="https://latex.codecogs.com/gif.latex?%5Clarge%201%20&plus;%203%20&plus;%205%20&plus;%20...&plus;%20%282k%20-%201%29&plus;%20%282%28k&plus;1%29%20-1%29%20%3D%20%28k&plus;1%29%5E%7B2%7D">
 </p>
 <br/>
 
 - **iii)** Mostrando-se a penúltima parcela , procedemos como segue:
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Clarge%201%20&plus;%203%20&plus;%205%20&plus;%20...&plus;%20%282k%20-%201%29&plus;%20%282%28k&plus;1%29%20-1%29%20%3D%20%28k&plus;1%29%5E%7B2%7D">
+  <img src="https://latex.codecogs.com/gif.latex?%5Clarge%201%20&plus;%203%20&plus;%205%20&plus;%20...&plus;%20%282k%20-%201%29&plus;%20%282%28k&plus;1%29%20-1%29%20%3D%20%28k&plus;1%29%5E%7B2%7D">
 </p>
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Clarge%20k%5E%7B2%7D%20&plus;%202%28k&plus;1%29%20-%201%20%3D%20%28k&plus;1%29%5E%7B2%7D">
+  <img src="https://latex.codecogs.com/gif.latex?%5Clarge%20k%5E%7B2%7D%20&plus;%202%28k&plus;1%29%20-%201%20%3D%20%28k&plus;1%29%5E%7B2%7D">
 </p>
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Clarge%20k%5E%7B2%7D%20&plus;%202k%20&plus;%201%3D%20%28k&plus;1%29%5E%7B2%7D">
+  <img src="https://latex.codecogs.com/gif.latex?%5Clarge%20k%5E%7B2%7D%20&plus;%202k%20&plus;%201%3D%20%28k&plus;1%29%5E%7B2%7D">
 </p>
 
 

--- a/ic/resumos/sistemasDeNumeracao.md
+++ b/ic/resumos/sistemasDeNumeracao.md
@@ -46,7 +46,7 @@ A leitura do resultado é feita do último quociente para o primeiro resto. Send
 
 Agora, vamos converter o número 10024 para hexadecimal:
 
-![Imagem 2](http://www.mecaweb.com.br/eletronica/content/image/conv_dh_2.png)
+![Imagem 2](https://imgur.com/ojVO5Zd) <!-- original: http://www.mecaweb.com.br/eletronica/content/image/conv_dh_2.png-->
 
 ## Qualquer Base Numérica para Decimal:
 
@@ -64,11 +64,11 @@ Deve-se utilizar a técnica de **agrupamento de bits**, associando 3 ou 4 bits a
 
 Como exemplo, vamos converter 21, em octal e em hexadecimal, para binário: 
 
-![Imagem 5](http://mundoprojetado.com.br/wp-content/uploads/2019/01/Conversao-de-octal-hexa-para-binario.png)
+![Imagem 5](https://imgur.com/Ytdi7uA) <!--Original: http://mundoprojetado.com.br/wp-content/uploads/2019/01/Conversao-de-octal-hexa-para-binario.png -->
 
 A seguir, vamos converter 001000110 de binário para octal e hexadecimal:
 
-![Imagem 6](http://mundoprojetado.com.br/wp-content/uploads/2019/01/Conversao-de-bin%C3%A1rio-em-octal-hexa.png)
+![Imagem 6](https://imgur.com/yq1vdcN) <!-- Original: http://mundoprojetado.com.br/wp-content/uploads/2019/01/Conversao-de-bin%C3%A1rio-em-octal-hexa.png-->
 
 ## Octal para Hexadecimal (e vice-versa):
 

--- a/probabilidade/leites/exerciciosResolvidos/estagio1.md
+++ b/probabilidade/leites/exerciciosResolvidos/estagio1.md
@@ -15,33 +15,33 @@ Os comprimentos, em centímetros, de 30 peças estão dados abaixo:
   - Para a o *q2* devemos fazer o cálculo da mediana:
     
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Clarge%20md%28x%29%20%3D%20%28x_%7B15%7D&plus;x_%7B16%7D%29/2%20%5CRightarrow%20md%28x%29%20%3D%204%2C135">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Clarge%20md%28x%29%20%3D%20%28x_%7B15%7D&plus;x_%7B16%7D%29/2%20%5CRightarrow%20md%28x%29%20%3D%204%2C135">
 </p>
 
   - Para a atribuição de *q1* e *q3* devemos analisar o elemento mediano da primeira e segunda metade do aglomerado ordenado de dados respectivamente:
     
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Clarge%20q_%7B1%7D%20%3D%20x_%7B8%7D%20%3D%202%2C82">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Clarge%20q_%7B1%7D%20%3D%20x_%7B8%7D%20%3D%202%2C82">
 </p>
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Clarge%20q_%7B3%7D%20%3D%20x_%7B23%7D%20%3D%205%2C41">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Clarge%20q_%7B3%7D%20%3D%20x_%7B23%7D%20%3D%205%2C41">
 </p>
 
   - Além destas, devemos encontrar as medidas: *LI*(Limite inferior), *LS*(Limite superior), *dq*(Diferença interquartílica), *min*(Valor mínimo), *max*(valor máximo):
   <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Clarge%20dq%20%3D%20q_%7B3%7D%20-%20q_%7B1%7D%20%5CRightarrow%20dq%20%3D%202%2C59">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Clarge%20dq%20%3D%20q_%7B3%7D%20-%20q_%7B1%7D%20%5CRightarrow%20dq%20%3D%202%2C59">
 </p>
   <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Clarge%20LI%20%3D%20q_%7B1%7D%20-%201%2C5.dq%20%5CRightarrow%20LI%20%3D%202%2C82%20-%203%2C885%20%3D%20-1%2C065">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Clarge%20LI%20%3D%20q_%7B1%7D%20-%201%2C5.dq%20%5CRightarrow%20LI%20%3D%202%2C82%20-%203%2C885%20%3D%20-1%2C065">
 </p>
   <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Clarge%20LS%20%3D%20q_%7B3%7D%20&plus;%201%2C5.dq%20%5CRightarrow%20LS%20%3D%205%2C41%20&plus;%203%2C885%20%3D%209%2C295">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Clarge%20LS%20%3D%20q_%7B3%7D%20&plus;%201%2C5.dq%20%5CRightarrow%20LS%20%3D%205%2C41%20&plus;%203%2C885%20%3D%209%2C295">
 </p>
   <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Clarge%20min%20%3D%20x_%7B1%7D%20%3D%200%2C90">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Clarge%20min%20%3D%20x_%7B1%7D%20%3D%200%2C90">
 </p>
   <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Clarge%20max%20%3D%20x_%7B30%7D%20%3D%208%2C45">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Clarge%20max%20%3D%20x_%7B30%7D%20%3D%208%2C45">
 </p>
 
   - O modelo do Box-Plot deve ficar parecido com o seguinte:
@@ -57,21 +57,21 @@ Os comprimentos, em centímetros, de 30 peças estão dados abaixo:
 
   - Idealmente, vamos atribuir o número de 5 classes(*k*) para esta resolução. Ainda precisamos dos valores do *Delta Total* e *Delta das classes*, que podem ser dados por:
    <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Clarge%20%5CDelta_%7Btot%7D%20%3D%20x_%7Bmax%7D%20-%20x_%7Bmin%7D%20%5CRightarrow%20%5CDelta_%7Btot%7D%20%3D%208%2C45%20-%200%2C90%20%3D%207%2C55">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Clarge%20%5CDelta_%7Btot%7D%20%3D%20x_%7Bmax%7D%20-%20x_%7Bmin%7D%20%5CRightarrow%20%5CDelta_%7Btot%7D%20%3D%208%2C45%20-%200%2C90%20%3D%207%2C55">
 </p>
   <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Clarge%20%5CDelta%20%3D%20%5Cfrac%7B%5CDelta_%7Btot%7D%7D%7Bk%7D%20%5CRightarrow%20%5CDelta%20%3D%20%5Cfrac%7B7%2C55%7D%7B5%7D%20%3D%201%2C51">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Clarge%20%5CDelta%20%3D%20%5Cfrac%7B%5CDelta_%7Btot%7D%7D%7Bk%7D%20%5CRightarrow%20%5CDelta%20%3D%20%5Cfrac%7B7%2C55%7D%7B5%7D%20%3D%201%2C51">
 </p>
 
   - Assim, temos a seguinte distribuição:
   
   **Comprimentos** | **Frequência Absoluta(*ni*)** | **Frequência Relativa(*fi*)** | **Porcentagem(*%*)** | **Frequência Acumulada**
   --- | --- | --- | --- | ---
-  ![](http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%200%2C90%20%5Cvdash%202%2C41) | 5 | 0,166 | 16,6 % | 5
-  ![](http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%202%2C41%20%5Cvdash%203%2C92) | 7 | 0,234 | 23,4 % | 12
-  ![](http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%203%2C92%20%5Cvdash%205%2C43) | 11 | 0,366 | 36,6 % | 23
-  ![](http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%205%2C43%20%5Cvdash%206%2C94) | 3 | 0,100 | 10,0 % | 26
-  ![](http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%206%2C94%20%5Cvdash%208%2C45) | 4 | 0,134 | 13,4 % | 30
+  ![](https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%200%2C90%20%5Cvdash%202%2C41) | 5 | 0,166 | 16,6 % | 5
+  ![](https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%202%2C41%20%5Cvdash%203%2C92) | 7 | 0,234 | 23,4 % | 12
+  ![](https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%203%2C92%20%5Cvdash%205%2C43) | 11 | 0,366 | 36,6 % | 23
+  ![](https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%205%2C43%20%5Cvdash%206%2C94) | 3 | 0,100 | 10,0 % | 26
+  ![](https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%206%2C94%20%5Cvdash%208%2C45) | 4 | 0,134 | 13,4 % | 30
   **Total** | 30 | 1 | 100,0 % | -
   
   - O histograma deve ter aparência do seguinte modelo:
@@ -85,11 +85,11 @@ O número de divórcios numa certa idade, de acordo com a duração do casamento
 
 **Anos de casamento** | **Número de divórcios**
 --- | ---
-![](http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%200%20%5Cvdash%206) | 2800
-![](http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%206%20%5Cvdash%2012) | 1400
-![](http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%2012%20%5Cvdash%2018) | 600
-![](http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%2018%20%5Cvdash%2024) | 150
-![](http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%2024%20%5Cvdash%2030) | 50
+![](https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%200%20%5Cvdash%206) | 2800
+![](https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%206%20%5Cvdash%2012) | 1400
+![](https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%2012%20%5Cvdash%2018) | 600
+![](https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%2018%20%5Cvdash%2024) | 150
+![](https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%2024%20%5Cvdash%2030) | 50
 **Total** | 5000
 
 **a)** Construa o histograma da distribuição.
@@ -107,12 +107,12 @@ O número de divórcios numa certa idade, de acordo com a duração do casamento
 **Resolução**
   - Para isto, devemos calcular a média com a seguinte fórmula:
   <p align="center">
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20%5Cbar%7Bx%7D%20%3D%20%5Cfrac%7B1%7D%7Bn%7D%5Csum_%7Bi%3D1%7D%5E%7Bk%7Dn_%7Bi%7D.s_%7Bi%7D">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20%5Cbar%7Bx%7D%20%3D%20%5Cfrac%7B1%7D%7Bn%7D%5Csum_%7Bi%3D1%7D%5E%7Bk%7Dn_%7Bi%7D.s_%7Bi%7D">
 </p>
  <p align="center">
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20%5Cbar%7Bx%7D%20%3D%20%5Cfrac%7B1%7D%7B5000%7D%282800.3%20&plus;%201400.9%20&plus;%20600.15%20&plus;%20150.21%20&plus;%2050.27%29">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20%5Cbar%7Bx%7D%20%3D%20%5Cfrac%7B1%7D%7B5000%7D%282800.3%20&plus;%201400.9%20&plus;%20600.15%20&plus;%20150.21%20&plus;%2050.27%29">
    <p align="center">
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20%5Cbar%7Bx%7D%20%5Csimeq%206%2C97">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20%5Cbar%7Bx%7D%20%5Csimeq%206%2C97">
 </p>
 
 **c)** Encontre a variância e o desvio padrâo de duração de casamentos.
@@ -120,21 +120,21 @@ O número de divórcios numa certa idade, de acordo com a duração do casamento
 **Resolução**
   - Para a variância, usaremos a seguinte fórmula:
   <p align="center">
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20var%28x%29%20%3D%20%5Csum_%7Bi%3D1%7D%5E%7Bk%7Df_%7Bi%7D%28x_%7Bi%7D-%5Cbar%7Bx%7D%29%5E2">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20var%28x%29%20%3D%20%5Csum_%7Bi%3D1%7D%5E%7Bk%7Df_%7Bi%7D%28x_%7Bi%7D-%5Cbar%7Bx%7D%29%5E2">
 </p>
    <p align="center">
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20var%28x%29%20%3D%200%2C56.%283-6%2C97%29%5E2%20&plus;0%2C28.%289-6%2C97%29%5E2&plus;0%2C12.%2815-6%2C97%29%5E2&plus;0%2C03.%2821-6%2C97%29%5E2%20&plus;%200%2C01.%2827-6%2C97%29%5E2">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20var%28x%29%20%3D%200%2C56.%283-6%2C97%29%5E2%20&plus;0%2C28.%289-6%2C97%29%5E2&plus;0%2C12.%2815-6%2C97%29%5E2&plus;0%2C03.%2821-6%2C97%29%5E2%20&plus;%200%2C01.%2827-6%2C97%29%5E2">
 </p>
   <p align="center">
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20var%28x%29%20%3D%2027%2C61">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20var%28x%29%20%3D%2027%2C61">
 </p>
 
   - Para o desvio padrão, temos a seguinte fórmula:
    <p align="center">
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20dp%28x%29%20%3D%20%5Csqrt%7Bvar%28x%29%7D">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20dp%28x%29%20%3D%20%5Csqrt%7Bvar%28x%29%7D">
 </p>
     <p align="center">
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20dp%28x%29%20%3D%205%2C25">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20dp%28x%29%20%3D%205%2C25">
 </p>
     
 
@@ -152,7 +152,7 @@ Uma companhia de seguros analisou a frequência com que 2000 segurados usaram o 
 **Resolução**
   - Para isto, vamos usar regra de três simples:
   <p align="center">
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20%5Cfrac%7B250%7D%7B100%5C%25%7D%20%3D%20%5Cfrac%7B100%7D%7Bx%7D%20%5CRightarrow%20250x%20%3D%20100%20%5CRightarrow%20x%20%3D%2040%5C%25">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20%5Cfrac%7B250%7D%7B100%5C%25%7D%20%3D%20%5Cfrac%7B100%7D%7Bx%7D%20%5CRightarrow%20250x%20%3D%20100%20%5CRightarrow%20x%20%3D%2040%5C%25">
 </p>
 
 **b)** Calcule a proporção de homens entre os indivíduos que não usaram o hospital.
@@ -160,7 +160,7 @@ Uma companhia de seguros analisou a frequência com que 2000 segurados usaram o 
 **Resolução**
   - Novamente, vamos usar regra de três simples:
   <p align="center">
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20%5Cfrac%7B1750%7D%7B100%5C%25%7D%20%3D%20%5Cfrac%7B900%7D%7Bx%7D%20%5CRightarrow%201750x%20%3D%20900%20%5CRightarrow%20x%20%3D%2051%2C42%5C%25">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20%5Cfrac%7B1750%7D%7B100%5C%25%7D%20%3D%20%5Cfrac%7B900%7D%7Bx%7D%20%5CRightarrow%201750x%20%3D%20900%20%5CRightarrow%20x%20%3D%2051%2C42%5C%25">
 </p>
 
 **c)** O uso do hospital independe do sexo do segurado? Justifique a sua resposta utilizando uma medida adequada de associação.
@@ -168,24 +168,24 @@ Uma companhia de seguros analisou a frequência com que 2000 segurados usaram o 
 **Resolução**
   - Para isto, precisamos encontrar o coeficiente de associação *T*, que é dado pela fórumla:
   <p align="center">
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20T%20%3D%20%5Csqrt%7B%5Cfrac%7B%5Cfrac%7Bx%5E2%7D%7Bn%7D%7D%7B%28r-1%29%28s-1%29%7D%7D">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20T%20%3D%20%5Csqrt%7B%5Cfrac%7B%5Cfrac%7Bx%5E2%7D%7Bn%7D%7D%7B%28r-1%29%28s-1%29%7D%7D">
 </p>
   
   - Onde:
   <p align="center">
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20x%5E2%20%3D%20%5Csum_%7Bi%3D1%7D%5E%7Br%7D%5Csum_%7Bj%3D1%7D%5E%7Bs%7D%5Cfrac%7B%28n_%7Bij%7D-n_%7Bij%7D%5E%7B*%7D%29%5E2%7D%7Bn_%7Bij%7D%5E%7B*%7D%7D">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20x%5E2%20%3D%20%5Csum_%7Bi%3D1%7D%5E%7Br%7D%5Csum_%7Bj%3D1%7D%5E%7Bs%7D%5Cfrac%7B%28n_%7Bij%7D-n_%7Bij%7D%5E%7B*%7D%29%5E2%7D%7Bn_%7Bij%7D%5E%7B*%7D%7D">
 </p>
   <p align="center">
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20x%5E2%20%3D%20%5Cfrac%7B%28100-125%29%5E2%7D%7B125%7D&plus;%5Cfrac%7B%28150-125%29%5E2%7D%7B125%7D%20&plus;%20%5Cfrac%7B%28900-875%29%5E2%7D%7B875%7D&plus;%5Cfrac%7B%28850-875%29%5E2%7D%7B875%7D">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20x%5E2%20%3D%20%5Cfrac%7B%28100-125%29%5E2%7D%7B125%7D&plus;%5Cfrac%7B%28150-125%29%5E2%7D%7B125%7D%20&plus;%20%5Cfrac%7B%28900-875%29%5E2%7D%7B875%7D&plus;%5Cfrac%7B%28850-875%29%5E2%7D%7B875%7D">
 </p>
   <p align="center">
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20x%5E2%20%3D%2011%2C43">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20x%5E2%20%3D%2011%2C43">
 </p>
 
   - Daí temos:
   
     <p align="center">
-      <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20T%20%3D%20%5Csqrt%7B%5Cfrac%7B%5Cfrac%7B11%2C43%7D%7B2000%7D%7D%7B1%7D%7D%5CRightarrow%20T%20%3D%200%2C07">
+      <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20T%20%3D%20%5Csqrt%7B%5Cfrac%7B%5Cfrac%7B11%2C43%7D%7B2000%7D%7D%7B1%7D%7D%5CRightarrow%20T%20%3D%200%2C07">
     </p>
     
   - Portanto, com o resultado obtido, definimos que há uma **associação fraca**.
@@ -200,19 +200,19 @@ Uma companhia de seguros analisou a frequência com que 2000 segurados usaram o 
   Você diria que a variável *X* pode ser usada para explicar a variação de *Y*? Justifique a sua resposta utilizando uma medida adequada de associação.
   - Cálculos auxiliares:
    <p align="center">
-      <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20%5Csum%20x%20%3D%2016%3B%20%5Csum%20y%20%3D%2022%3B%20%5Csum%20xy%20%3D%2053%3B%5Csum%20x%5E2%3D62%3B%20%5Csum%20y%5E2%3D130">
+      <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20%5Csum%20x%20%3D%2016%3B%20%5Csum%20y%20%3D%2022%3B%20%5Csum%20xy%20%3D%2053%3B%5Csum%20x%5E2%3D62%3B%20%5Csum%20y%5E2%3D130">
     </p>
     
 **Resolução:**
   - Vamos usar a seguinte fórmula:
   <p align="center">
-      <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20corr%28x%2C%20y%29%20%3D%20%5Cfrac%7B%5Csum_%7Bi%3D1%7D%5E%7Bn%7Dx_%7Bi%7Dy_%7Bi%7D%20-%20n%5Cbar%7Bx%7D%5Cbar%7By%7D%7D%7B%5Csqrt%7B%28%5Csum_%7Bi%3D1%7D%5E%7Bn%7Dx_%7Bi%7D%5E2%20-%20n%5Cbar%7Bx%7D%5E2%29%28%5Csum_%7Bi%3D1%7D%5E%7Bn%7Dy_%7Bi%7D%5E2%20-%20n%5Cbar%7By%7D%5E2%29%7D%7D">
+      <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20corr%28x%2C%20y%29%20%3D%20%5Cfrac%7B%5Csum_%7Bi%3D1%7D%5E%7Bn%7Dx_%7Bi%7Dy_%7Bi%7D%20-%20n%5Cbar%7Bx%7D%5Cbar%7By%7D%7D%7B%5Csqrt%7B%28%5Csum_%7Bi%3D1%7D%5E%7Bn%7Dx_%7Bi%7D%5E2%20-%20n%5Cbar%7Bx%7D%5E2%29%28%5Csum_%7Bi%3D1%7D%5E%7Bn%7Dy_%7Bi%7D%5E2%20-%20n%5Cbar%7By%7D%5E2%29%7D%7D">
     </p>
     <p align="center">
-      <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20corr%28x%2C%20y%29%20%3D%20%5Cfrac%7B53%20-%285x3%2C2x4%2C4%29%7D%7B%5Csqrt%7B%5B62%20-%205x%283%2C2%29%5E2%5D%5B130%20-%205x%284%2C4%29%5E2%5D%7D%7D">
+      <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20corr%28x%2C%20y%29%20%3D%20%5Cfrac%7B53%20-%285x3%2C2x4%2C4%29%7D%7B%5Csqrt%7B%5B62%20-%205x%283%2C2%29%5E2%5D%5B130%20-%205x%284%2C4%29%5E2%5D%7D%7D">
     </p>
     <p align="center">
-      <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20%7Ccorr%28x%2C%20y%29%7C%20%3D%20%5Cfrac%7B-17%2C4%7D%7B18%2C9%7D%20%5CRightarrow%20%7Ccorr%28x%2Cy%29%7C%20%3D%200%2C92">
+      <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20%7Ccorr%28x%2C%20y%29%7C%20%3D%20%5Cfrac%7B-17%2C4%7D%7B18%2C9%7D%20%5CRightarrow%20%7Ccorr%28x%2Cy%29%7C%20%3D%200%2C92">
     </p>
     
   - Portanto, dizemos que há uma **associação forte** entre as variáveis.

--- a/probabilidade/leites/exerciciosResolvidos/estagio2.md
+++ b/probabilidade/leites/exerciciosResolvidos/estagio2.md
@@ -10,7 +10,7 @@ De 120 estudantes, 60 estudam francês, 50 espanhol, e 20 estudam francês e esp
 
   - Denotamos *A* como *estudante de francês* e *B* como *estudante de espanhol*, daí temos:
  <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28A%5Ccap%20B%29%20%3D%20%5Cfrac%7B20%7D%7B120%7D%20%3D%20%5Cfrac%7B1%7D%7B6%7D">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28A%5Ccap%20B%29%20%3D%20%5Cfrac%7B20%7D%7B120%7D%20%3D%20%5Cfrac%7B1%7D%7B6%7D">
 </p>
 
 **b)** estude pelo menos um dos idiomas.
@@ -19,13 +19,13 @@ De 120 estudantes, 60 estudam francês, 50 espanhol, e 20 estudam francês e esp
 
   - Usaremos a propriedade de disjunção:
    <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28A%5Ccup%20B%20%29%20%3D%20P%28A%29%20&plus;P%28B%29%20-%20P%28A%5Ccap%20B%29">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28A%5Ccup%20B%20%29%20%3D%20P%28A%29%20&plus;P%28B%29%20-%20P%28A%5Ccap%20B%29">
 </p>
   <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28A%5Ccup%20B%20%29%20%3D%20%5Cfrac%7B60%7D%7B120%7D%20&plus;%20%5Cfrac%7B50%7D%7B120%7D-%20%5Cfrac%7B1%7D%7B6%7D">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28A%5Ccup%20B%20%29%20%3D%20%5Cfrac%7B60%7D%7B120%7D%20&plus;%20%5Cfrac%7B50%7D%7B120%7D-%20%5Cfrac%7B1%7D%7B6%7D">
 </p>
   <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28A%5Ccup%20B%20%29%20%3D%20%5Cfrac%7B3%7D%7B4%7D">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28A%5Ccup%20B%20%29%20%3D%20%5Cfrac%7B3%7D%7B4%7D">
 </p>
 
 **c)** não estude nem francês nem espanhol.
@@ -34,10 +34,10 @@ De 120 estudantes, 60 estudam francês, 50 espanhol, e 20 estudam francês e esp
   
   - Para isto, usaremos a Lei de De Morgan:
    <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28%5Cbar%7BA%7D%5Ccap%20%5Cbar%7BB%7D%29%20%3D%20P%5Coverline%7B%28A%5Ccup%20B%29%7D">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28%5Cbar%7BA%7D%5Ccap%20%5Cbar%7BB%7D%29%20%3D%20P%5Coverline%7B%28A%5Ccup%20B%29%7D">
 </p>
   <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%5Coverline%7B%28A%5Ccup%20B%29%7D%20%3D%201%20-%20P%28A%5Ccup%20B%29%20%3D%20%5Cfrac%7B1%7D%7B4%7D">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%5Coverline%7B%28A%5Ccup%20B%29%7D%20%3D%201%20-%20P%28A%5Ccup%20B%29%20%3D%20%5Cfrac%7B1%7D%7B4%7D">
 </p>
 
 ## Questão 2 
@@ -50,38 +50,38 @@ Um lote é composto por 10 artigos bons, 4 com defeitos menores e 2 com defeitos
 
 **a)** ambos sejam bons.
  <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28B%5Ccap%20B%29%20%3D%20%5Cfrac%7B10%7D%7B16%7D.%5Cfrac%7B9%7D%7B15%7D%20%3D%20%5Cfrac%7B3%7D%7B8%7D">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28B%5Ccap%20B%29%20%3D%20%5Cfrac%7B10%7D%7B16%7D.%5Cfrac%7B9%7D%7B15%7D%20%3D%20%5Cfrac%7B3%7D%7B8%7D">
 </p>
 
 **b)** ambos tenham defeitos graves.
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28G%5Ccap%20G%29%20%3D%20%5Cfrac%7B2%7D%7B16%7D.%5Cfrac%7B1%7D%7B15%7D%20%3D%20%5Cfrac%7B1%7D%7B120%7D">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28G%5Ccap%20G%29%20%3D%20%5Cfrac%7B2%7D%7B16%7D.%5Cfrac%7B1%7D%7B15%7D%20%3D%20%5Cfrac%7B1%7D%7B120%7D">
 </p>
 
 **c)** ao menos um seja bom.
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28B%29%20&plus;%20P%28M%5Ccap%20B%29%20&plus;%20P%28G%5Ccap%20B%29%20%3D%20%5Cfrac%7B10%7D%7B16%7D%20&plus;%20%5Cfrac%7B4%7D%7B16%7D.%5Cfrac%7B10%7D%7B15%7D&plus;%5Cfrac%7B2%7D%7B16%7D.%5Cfrac%7B10%7D%7B15%7D%20%3D%20%5Cfrac%7B7%7D%7B8%7D">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28B%29%20&plus;%20P%28M%5Ccap%20B%29%20&plus;%20P%28G%5Ccap%20B%29%20%3D%20%5Cfrac%7B10%7D%7B16%7D%20&plus;%20%5Cfrac%7B4%7D%7B16%7D.%5Cfrac%7B10%7D%7B15%7D&plus;%5Cfrac%7B2%7D%7B16%7D.%5Cfrac%7B10%7D%7B15%7D%20%3D%20%5Cfrac%7B7%7D%7B8%7D">
 </p>
 
 **d)** no máximo um seja bom.
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%5Coverline%7B%28B%5Ccap%20B%29%7D%20%3D%201%20-%20P%28B%5Ccap%20B%29%20%3D%20%5Cfrac%7B5%7D%7B8%7D">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%5Coverline%7B%28B%5Ccap%20B%29%7D%20%3D%201%20-%20P%28B%5Ccap%20B%29%20%3D%20%5Cfrac%7B5%7D%7B8%7D">
 </p>
 
 **e)** exatamente um seja bom.
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28B%5Ccap%20M%29%20&plus;P%28B%5Ccap%20G%29%20&plus;P%28M%5Ccap%20B%29%20&plus;P%28G%5Ccap%20B%29%20%3D%20%5Cfrac%7B1%7D%7B2%7D">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28B%5Ccap%20M%29%20&plus;P%28B%5Ccap%20G%29%20&plus;P%28M%5Ccap%20B%29%20&plus;P%28G%5Ccap%20B%29%20%3D%20%5Cfrac%7B1%7D%7B2%7D">
 </p>
 
 **f)** nenhum tenha defeito grave.
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28B%5Ccap%20B%29%20&plus;P%28B%5Ccap%20M%29%20&plus;P%28M%5Ccap%20B%29%20&plus;P%28M%5Ccap%20M%29%20%3D%20%5Cfrac%7B31%7D%7B40%7D">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28B%5Ccap%20B%29%20&plus;P%28B%5Ccap%20M%29%20&plus;P%28M%5Ccap%20B%29%20&plus;P%28M%5Ccap%20M%29%20%3D%20%5Cfrac%7B31%7D%7B40%7D">
 </p>
 
 **g)** nenhum seja bom.
   - Usaremos o complemento da letra c).
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28%5Coverline%7Bc%7D%29%20%3D%201%20-%20P%28c%29%20%3D%20%5Cfrac%7B1%7D%7B8%7D">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28%5Coverline%7Bc%7D%29%20%3D%201%20-%20P%28c%29%20%3D%20%5Cfrac%7B1%7D%7B8%7D">
 </p>
 
 ## Questão 3
@@ -93,24 +93,24 @@ Em uma indústria, a experiência indica que há uma probabilidade de 90% de um 
 
   - Para isto, vamos usar probabilidade condicional:
   <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28N_%7Bc%7D%29%20%3D%2080%5C%25">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28N_%7Bc%7D%29%20%3D%2080%5C%25">
 </p>
 
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28N_%7Bs%7D%29%20%3D%2020%5C%25">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28N_%7Bs%7D%29%20%3D%2020%5C%25">
 </p>
 
   - Sendo *C* o evento *"cumpriu a cota"*, temos que:
   <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28C%29%20%3D%20P%28N_%7Bc%7D%29.P%28C%7CN_%7Bc%7D%29&plus;P%28N_%7Bs%7D%29.P%28C%7CN_%7Bs%7D%29">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28C%29%20%3D%20P%28N_%7Bc%7D%29.P%28C%7CN_%7Bc%7D%29&plus;P%28N_%7Bs%7D%29.P%28C%7CN_%7Bs%7D%29">
 </p>
 
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28C%29%20%3D%200.8*0.9&plus;0.2*0.45">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28C%29%20%3D%200.8*0.9&plus;0.2*0.45">
 </p>
 
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28C%29%20%3D%200.81">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28C%29%20%3D%200.81">
 </p>
 
 **b)** A probabilidade de ele ter feito o curso de treinamento, dado que ele não cumpriu a cota de produção.
@@ -118,21 +118,21 @@ Em uma indústria, a experiência indica que há uma probabilidade de 90% de um 
 **Resolução:**
 
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28N_%7Bc%7D%7CC%29%20%3D%20%5Cfrac%7BP%28%5Coverline%7BC%7D%7CN_%7Bc%7D%29.P%28N_%7Bc%7D%29%7D%7BP%28%5Coverline%7BC%7D%29%7D">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28N_%7Bc%7D%7CC%29%20%3D%20%5Cfrac%7BP%28%5Coverline%7BC%7D%7CN_%7Bc%7D%29.P%28N_%7Bc%7D%29%7D%7BP%28%5Coverline%7BC%7D%29%7D">
 </p>
 
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28N_%7Bc%7D%7CC%29%20%3D%20%5Cfrac%7B0.1*0.8%7D%7B0.19%7D">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28N_%7Bc%7D%7CC%29%20%3D%20%5Cfrac%7B0.1*0.8%7D%7B0.19%7D">
 </p>
 
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28N_%7Bc%7D%7CC%29%20%3D%200.421">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28N_%7Bc%7D%7CC%29%20%3D%200.421">
 </p>
 
 ## Questão 4
 Suponha que a demanda por certa peça, numa loja de automóveis siga o seguinte modelo:
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28X%3Dk%29%20%3D%5Cfrac%7Ba*2%5E%7Bk%7D%7D%7Bk%21%7D%2C%20k%20%3D%201%2C%202%2C%203%2C%204.">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28X%3Dk%29%20%3D%5Cfrac%7Ba*2%5E%7Bk%7D%7D%7Bk%21%7D%2C%20k%20%3D%201%2C%202%2C%203%2C%204.">
 </p>
 
 **a)** Encontre o valor de *a*.
@@ -141,15 +141,15 @@ Suponha que a demanda por certa peça, numa loja de automóveis siga o seguinte 
 
   - Para isto, vamos deduzir que o somatório das probabilidades seja igual a 1, então temos:
   <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28X%3Dk%29%20%3D%20a%28%5Cfrac%7B2%5E%7B1%7D%7D%7B1%7D%20&plus;%20%5Cfrac%7B2%5E%7B2%7D%7D%7B2%7D%20&plus;%20%5Cfrac%7B2%5E%7B3%7D%7D%7B6%7D%20&plus;%20%5Cfrac%7B2%5E%7B4%7D%7D%7B24%7D%29%20%3D%201">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28X%3Dk%29%20%3D%20a%28%5Cfrac%7B2%5E%7B1%7D%7D%7B1%7D%20&plus;%20%5Cfrac%7B2%5E%7B2%7D%7D%7B2%7D%20&plus;%20%5Cfrac%7B2%5E%7B3%7D%7D%7B6%7D%20&plus;%20%5Cfrac%7B2%5E%7B4%7D%7D%7B24%7D%29%20%3D%201">
 </p>
 
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20a%282%20&plus;%202%20&plus;%20%5Cfrac%7B4%7D%7B3%7D%20&plus;%20%5Cfrac%7B2%7D%7B3%7D%29%20%3D%201">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20a%282%20&plus;%202%20&plus;%20%5Cfrac%7B4%7D%7B3%7D%20&plus;%20%5Cfrac%7B2%7D%7B3%7D%29%20%3D%201">
 </p>
 
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20a%20%3D%20%5Cfrac%7B1%7D%7B6%7D">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20a%20%3D%20%5Cfrac%7B1%7D%7B6%7D">
 </p>
 
 **b)** Calcule a probabilidade da demanda ser inferior a duas peças.
@@ -157,7 +157,7 @@ Suponha que a demanda por certa peça, numa loja de automóveis siga o seguinte 
 **Resolução:**
 
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28X%20%3C%202%29%3D%5Cfrac%7B1*2%5E%7B1%7D%7D%7B6*1%21%7D%3D%5Cfrac%7B1%7D%7B3%7D">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28X%20%3C%202%29%3D%5Cfrac%7B1*2%5E%7B1%7D%7D%7B6*1%21%7D%3D%5Cfrac%7B1%7D%7B3%7D">
 </p>
 
 **c)** Calcule a F.d.a. de X.
@@ -165,14 +165,14 @@ Suponha que a demanda por certa peça, numa loja de automóveis siga o seguinte 
 **Resolução:**
 
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20F%28X%29%20%3D%20%5Cleft%20%5C%7B%20%5Cbegin%7Bmatrix%7D%200%2C%20%26%20%5Cmbox%7Bse%20%7Dx%20%3C%201%2C%20%5C%5C%20%5Cfrac%7B1%7D%7B3%7D%2C%20%26%20%5Cmbox%7Bse%20%7D%201%5Cleq%20x%20%3C%202%2C%20%5C%5C%20%5Cfrac%7B1%7D%7B3%7D%2C%20%26%20%5Cmbox%7Bse%20%7D%202%5Cleq%20x%20%3C%203%2C%20%5C%5C%20%5Cfrac%7B2%7D%7B9%7D%2C%20%26%20%5Cmbox%7Bse%20%7D%203%5Cleq%20x%20%3C%204%2C%20%5C%5C%20%5Cfrac%7B1%7D%7B9%7D%2C%20%26%20%5Cmbox%7Bse%20%7D%20x%20%5Cgeq%204%20%5C%5C%20%5Cend%7Bmatrix%7D%20%5Cright.">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20F%28X%29%20%3D%20%5Cleft%20%5C%7B%20%5Cbegin%7Bmatrix%7D%200%2C%20%26%20%5Cmbox%7Bse%20%7Dx%20%3C%201%2C%20%5C%5C%20%5Cfrac%7B1%7D%7B3%7D%2C%20%26%20%5Cmbox%7Bse%20%7D%201%5Cleq%20x%20%3C%202%2C%20%5C%5C%20%5Cfrac%7B1%7D%7B3%7D%2C%20%26%20%5Cmbox%7Bse%20%7D%202%5Cleq%20x%20%3C%203%2C%20%5C%5C%20%5Cfrac%7B2%7D%7B9%7D%2C%20%26%20%5Cmbox%7Bse%20%7D%203%5Cleq%20x%20%3C%204%2C%20%5C%5C%20%5Cfrac%7B1%7D%7B9%7D%2C%20%26%20%5Cmbox%7Bse%20%7D%20x%20%5Cgeq%204%20%5C%5C%20%5Cend%7Bmatrix%7D%20%5Cright.">
 </p>
 
 ## Questão 5
 Dada a função:
 
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20f%28x%29%20%3D%20%5Cleft%20%5C%7B%20%5Cbegin%7Bmatrix%7D%202e%5E%7B-2x%7D%2C%20%26%20%5Cmbox%7Bse%20%7Dx%20%5Cgeq%200%2C%20%5C%5C%200%2C%20%26%20%5Cmbox%7Bse%20%7D%20x%20%3C%200%20%5C%5C%20%5Cend%7Bmatrix%7D%20%5Cright.">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20f%28x%29%20%3D%20%5Cleft%20%5C%7B%20%5Cbegin%7Bmatrix%7D%202e%5E%7B-2x%7D%2C%20%26%20%5Cmbox%7Bse%20%7Dx%20%5Cgeq%200%2C%20%5C%5C%200%2C%20%26%20%5Cmbox%7Bse%20%7D%20x%20%3C%200%20%5C%5C%20%5Cend%7Bmatrix%7D%20%5Cright.">
 </p>
 
 **a)** Mostre que esta função é uma *f.d.p.*.
@@ -180,11 +180,11 @@ Dada a função:
 **Resolução:**
 
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20%5Cint_%7B0%7D%5E%7B%5Cinfty%7D2e%5E%7B-2x%7Ddx%20%3D%202%20%5Cleft%20%5B%20%5Cfrac%7Be%5E%7B-2x%7D%7D%7B-2%7D%20%5Cright%20%5D_%7B0%7D%5E%7B%5Cinfty%7D">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20%5Cint_%7B0%7D%5E%7B%5Cinfty%7D2e%5E%7B-2x%7Ddx%20%3D%202%20%5Cleft%20%5B%20%5Cfrac%7Be%5E%7B-2x%7D%7D%7B-2%7D%20%5Cright%20%5D_%7B0%7D%5E%7B%5Cinfty%7D">
 </p>
 
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20%3D%202%5Cleft%20%5B%200%20&plus;%20%5Cfrac%7Be%5E%7B-0%7D%7D%7B2%7D%20%5Cright%20%5D%20%3D%201">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20%3D%202%5Cleft%20%5B%200%20&plus;%20%5Cfrac%7Be%5E%7B-0%7D%7D%7B2%7D%20%5Cright%20%5D%20%3D%201">
 </p>
 
 **b)** Obtenha a função de distribuição de *x* e calcule a probabilidade de *x > 10*.
@@ -192,22 +192,22 @@ Dada a função:
 **Resolução:**
 
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20F%28x%29%20%3D%5Cint_%7Bx%7D%5E%7B%5Cinfty%7D%202e%5E%7B-2x%7Ddx%20%3D%202%5Cleft%20%5B%20%5Cfrac%7Be%5E%7B-2x%7D%7D%7B-2%7D%20%5Cright%20%5D_%7Bx%7D%5E%7B%5Cinfty%7D%20%3D%202%5Cleft%20%5B%200%20&plus;%20%5Cfrac%7Be%5E%7B-2x%7D%7D%7B2%7D%20%5Cright%20%5D">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20F%28x%29%20%3D%5Cint_%7Bx%7D%5E%7B%5Cinfty%7D%202e%5E%7B-2x%7Ddx%20%3D%202%5Cleft%20%5B%20%5Cfrac%7Be%5E%7B-2x%7D%7D%7B-2%7D%20%5Cright%20%5D_%7Bx%7D%5E%7B%5Cinfty%7D%20%3D%202%5Cleft%20%5B%200%20&plus;%20%5Cfrac%7Be%5E%7B-2x%7D%7D%7B2%7D%20%5Cright%20%5D">
 </p>
 
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20F%28x%29%20%3D%20e%5E%7B-2x%7D">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20F%28x%29%20%3D%20e%5E%7B-2x%7D">
 </p>
 
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20F%2810%29%20%3D%20P%28x%3E10%29%20%3D%20e%5E%7B-20%7D">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20F%2810%29%20%3D%20P%28x%3E10%29%20%3D%20e%5E%7B-20%7D">
 </p>
 
 ## Questão 6
 Uma variável aleatória *x* tem distribuição triangular no intervalor [0, 1] se fua *f.d.p.* for dada por:
 
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20f%28x%29%20%3D%5Cleft%5C%7B%5Cbegin%7Bmatrix%7D%200%2C%20%26%20x%20%3C%200%20%5C%5C%20Cx%2C%20%26%200%5Cleq%20x%20%5Cleq%20%5Cfrac%7B1%7D%7B2%7D%20%5C%5C%20C%281-x%29%2C%20%26%20%5Cfrac%7B1%7D%7B2%7D%20%5Cleq%20x%20%5Cleq%201%20%5C%5C%200%2C%20%26%20x%20%3E%201%20%5Cend%7Bmatrix%7D%5Cright.">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20f%28x%29%20%3D%5Cleft%5C%7B%5Cbegin%7Bmatrix%7D%200%2C%20%26%20x%20%3C%200%20%5C%5C%20Cx%2C%20%26%200%5Cleq%20x%20%5Cleq%20%5Cfrac%7B1%7D%7B2%7D%20%5C%5C%20C%281-x%29%2C%20%26%20%5Cfrac%7B1%7D%7B2%7D%20%5Cleq%20x%20%5Cleq%201%20%5C%5C%200%2C%20%26%20x%20%3E%201%20%5Cend%7Bmatrix%7D%5Cright.">
 </p>
 
 **a)** Qual valor deve ter a constante *C*?
@@ -217,19 +217,19 @@ Uma variável aleatória *x* tem distribuição triangular no intervalor [0, 1] 
   - Para isto, vamos usar o somatório de integral:
   
   <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20%5Cint_%7B-%5Cinfty%7D%5E%7B%5Cinfty%7Df%28x%29.dx%20%3D%20%5Cint_%7B-%5Cinfty%7D%5E%7B0%7D0.dx%20&plus;%20%5Cint_%7B0%7D%5E%7B%5Cfrac%7B1%7D%7B2%7D%7DCx.dx%20&plus;%20%5Cint_%7B%5Cfrac%7B1%7D%7B2%7D%7D%5E%7B1%7DC%281-x%29.dx%20&plus;%20%5Cint_%7B1%7D%5E%7B%5Cinfty%7D0.dx%20%3D%201">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20%5Cint_%7B-%5Cinfty%7D%5E%7B%5Cinfty%7Df%28x%29.dx%20%3D%20%5Cint_%7B-%5Cinfty%7D%5E%7B0%7D0.dx%20&plus;%20%5Cint_%7B0%7D%5E%7B%5Cfrac%7B1%7D%7B2%7D%7DCx.dx%20&plus;%20%5Cint_%7B%5Cfrac%7B1%7D%7B2%7D%7D%5E%7B1%7DC%281-x%29.dx%20&plus;%20%5Cint_%7B1%7D%5E%7B%5Cinfty%7D0.dx%20%3D%201">
 </p>
 
  <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20%5Cint_%7B-%5Cinfty%7D%5E%7B%5Cinfty%7Df%28x%29.dx%20%3D%20C%5Cleft%20%28%20%5Cleft%20%5B%20%5Cfrac%7Bx%5E2%7D%7B2%7D%20%5Cright%20%5D_%7B0%7D%5E%7B%5Cfrac%7B1%7D%7B2%7D%7D%20&plus;%20%5Cleft%20%5B%20x%20-%20%5Cfrac%7Bx%5E2%7D%7B2%7D%20%5Cright%20%5D_%7B%5Cfrac%7B1%7D%7B2%7D%7D%5E%7B1%7D%20%5Cright%20%29">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20%5Cint_%7B-%5Cinfty%7D%5E%7B%5Cinfty%7Df%28x%29.dx%20%3D%20C%5Cleft%20%28%20%5Cleft%20%5B%20%5Cfrac%7Bx%5E2%7D%7B2%7D%20%5Cright%20%5D_%7B0%7D%5E%7B%5Cfrac%7B1%7D%7B2%7D%7D%20&plus;%20%5Cleft%20%5B%20x%20-%20%5Cfrac%7Bx%5E2%7D%7B2%7D%20%5Cright%20%5D_%7B%5Cfrac%7B1%7D%7B2%7D%7D%5E%7B1%7D%20%5Cright%20%29">
 </p>
 
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20C%5Cleft%20%28%20%5Cfrac%7B1%7D%7B8%7D%20&plus;%201%20-%20%5Cfrac%7B1%7D%7B2%7D%20-%20%5Cfrac%7B1%7D%7B2%7D%20&plus;%20%5Cfrac%7B1%7D%7B8%7D%20%5Cright%20%29%20%3D%201">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20C%5Cleft%20%28%20%5Cfrac%7B1%7D%7B8%7D%20&plus;%201%20-%20%5Cfrac%7B1%7D%7B2%7D%20-%20%5Cfrac%7B1%7D%7B2%7D%20&plus;%20%5Cfrac%7B1%7D%7B8%7D%20%5Cright%20%29%20%3D%201">
 </p>
 
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20C%20%3D%204">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20C%20%3D%204">
 </p>
 
 **b)** Determine *P(x < 1/2)*, *P(x > 1/2)*, e *P(1/4 < x < 3/4)*.
@@ -238,26 +238,26 @@ Uma variável aleatória *x* tem distribuição triangular no intervalor [0, 1] 
 
   - Para P(x < 1/2):
   <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28x%20%3C%201/2%29%20%3D%20%5Cint_%7B0%7D%5E%7B%5Cfrac%7B1%7D%7B2%7D%7Df%28x%29.dx%20%5CRightarrow%20%5Cint_%7B0%7D%5E%7B%5Cfrac%7B1%7D%7B2%7D%7D4x.dx%20%5CRightarrow%204%5Cleft%20%5B%20%5Cfrac%7Bx%5E2%7D%7B2%7D%20%5Cright%20%5D_%7B0%7D%5E%7B%5Cfrac%7B1%7D%7B2%7D%7D">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28x%20%3C%201/2%29%20%3D%20%5Cint_%7B0%7D%5E%7B%5Cfrac%7B1%7D%7B2%7D%7Df%28x%29.dx%20%5CRightarrow%20%5Cint_%7B0%7D%5E%7B%5Cfrac%7B1%7D%7B2%7D%7D4x.dx%20%5CRightarrow%204%5Cleft%20%5B%20%5Cfrac%7Bx%5E2%7D%7B2%7D%20%5Cright%20%5D_%7B0%7D%5E%7B%5Cfrac%7B1%7D%7B2%7D%7D">
 </p>
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28x%20%3C%201/2%29%20%3D%20%5Cfrac%7B1%7D%7B2%7D">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28x%20%3C%201/2%29%20%3D%20%5Cfrac%7B1%7D%7B2%7D">
 </p>
 
   - Para P(x > 1/2), temos o complemento do item anterior, então:
   
   <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28x%20%3E%201/2%29%20%3D%20%5Cfrac%7B1%7D%7B2%7D">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28x%20%3E%201/2%29%20%3D%20%5Cfrac%7B1%7D%7B2%7D">
 </p>
 
   - Para P(1/4 < x < 3/4):
   
   <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%5Cleft%20%28%20%5Cfrac%7B1%7D%7B4%7D%20%3C%20x%20%3C%20%5Cfrac%7B3%7D%7B4%7D%20%5Cright%20%29%20%3D%20%5Cint_%7B%5Cfrac%7B1%7D%7B4%7D%7D%5E%7B%5Cfrac%7B3%7D%7B4%7D%7Df%28x%29.dx%20%5CRightarrow%20%5Cint_%7B%5Cfrac%7B1%7D%7B4%7D%7D%5E%7B%5Cfrac%7B1%7D%7B2%7D%7D4x.dx%20&plus;%20%5Cint_%7B%5Cfrac%7B1%7D%7B2%7D%7D%5E%7B%5Cfrac%7B3%7D%7B4%7D%7D4%281-x%29.dx">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%5Cleft%20%28%20%5Cfrac%7B1%7D%7B4%7D%20%3C%20x%20%3C%20%5Cfrac%7B3%7D%7B4%7D%20%5Cright%20%29%20%3D%20%5Cint_%7B%5Cfrac%7B1%7D%7B4%7D%7D%5E%7B%5Cfrac%7B3%7D%7B4%7D%7Df%28x%29.dx%20%5CRightarrow%20%5Cint_%7B%5Cfrac%7B1%7D%7B4%7D%7D%5E%7B%5Cfrac%7B1%7D%7B2%7D%7D4x.dx%20&plus;%20%5Cint_%7B%5Cfrac%7B1%7D%7B2%7D%7D%5E%7B%5Cfrac%7B3%7D%7B4%7D%7D4%281-x%29.dx">
 </p>
 
   <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%5Cleft%20%28%20%5Cfrac%7B1%7D%7B4%7D%20%3C%20x%20%3C%20%5Cfrac%7B3%7D%7B4%7D%20%5Cright%20%29%20%3D%20%5Cfrac%7B3%7D%7B4%7D">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%5Cleft%20%28%20%5Cfrac%7B1%7D%7B4%7D%20%3C%20x%20%3C%20%5Cfrac%7B3%7D%7B4%7D%20%5Cright%20%29%20%3D%20%5Cfrac%7B3%7D%7B4%7D">
 </p>
 
 
@@ -265,7 +265,7 @@ Uma variável aleatória *x* tem distribuição triangular no intervalor [0, 1] 
 Suponha que estamos atirando dardos num alvo circular de raio 10cm, e seja *x* a distância do ponto atingido pelo dardo ao centro do alvo. A *f.d.p.* de *x* é:
 
  <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20f%28x%29%3D%5Cleft%5C%7B%5Cbegin%7Bmatrix%7D%20kx%2C%20%26%200%20%5Cleq%20x%20%5Cleq%2010%20%5C%5C%200%2C%20%26%20c.c.%20%5Cend%7Bmatrix%7D%5Cright.">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20f%28x%29%3D%5Cleft%5C%7B%5Cbegin%7Bmatrix%7D%20kx%2C%20%26%200%20%5Cleq%20x%20%5Cleq%2010%20%5C%5C%200%2C%20%26%20c.c.%20%5Cend%7Bmatrix%7D%5Cright.">
 </p>
 
 **a)** Qual a probabilidade de acertar o centro do alvo, se esse for um círculo de 1cm de raio?
@@ -275,15 +275,15 @@ Suponha que estamos atirando dardos num alvo circular de raio 10cm, e seja *x* a
   - Como *P(x < 10) = 1*, temos que:
   
   <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20%5Cint_%7B0%7D%5E%7B10%7Dkx.dx%20%3D%201%20%5CRightarrow%20k%5Cleft%20%5B%20%5Cfrac%7Bx%5E2%7D%7B2%7D%20%5Cright%20%5D_%7B0%7D%5E%7B10%7D%20%3D%201%20%5CRightarrow%20k%20%3D%200.02">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20%5Cint_%7B0%7D%5E%7B10%7Dkx.dx%20%3D%201%20%5CRightarrow%20k%5Cleft%20%5B%20%5Cfrac%7Bx%5E2%7D%7B2%7D%20%5Cright%20%5D_%7B0%7D%5E%7B10%7D%20%3D%201%20%5CRightarrow%20k%20%3D%200.02">
 </p>
 
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20%5Ctherefore%20F%28x%29%20%3D%20%5Cint_%7B0%7D%5E%7Bx%7D0.02x.dx%20%3D%200%2C01x%5E2">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20%5Ctherefore%20F%28x%29%20%3D%20%5Cint_%7B0%7D%5E%7Bx%7D0.02x.dx%20%3D%200%2C01x%5E2">
 </p>
 
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20F%281%29%20%3D%20P%28x%5Cleq%201%29%20%3D%200%2C01">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20F%281%29%20%3D%20P%28x%5Cleq%201%29%20%3D%200%2C01">
 </p>
 
 **b)** Mostre que a probabilidade de acertar qualquer círculo concêntrico é proporcional â sua área.
@@ -291,14 +291,14 @@ Suponha que estamos atirando dardos num alvo circular de raio 10cm, e seja *x* a
 **Resolução:**
 
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28x%20%3C%20r%29%20%3D%200.01r%5E2%20%3D%20%5Cfrac%7B%5Cpi%20r%5E2%7D%7B%5Cpi%2010%5E2%7D">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28x%20%3C%20r%29%20%3D%200.01r%5E2%20%3D%20%5Cfrac%7B%5Cpi%20r%5E2%7D%7B%5Cpi%2010%5E2%7D">
 </p>
 
 ## Questão 8
 Encontre o valor da constante *C* se
 
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20f%28x%29%3D%5Cleft%5C%7B%5Cbegin%7Bmatrix%7D%20%5Cfrac%7BC%7D%7Bx%5E2%7D%2C%20%26%20x%5Cgeq%2010%20%5C%5C%200%2C%20%26%20x%20%3C%2010%20%5Cend%7Bmatrix%7D%5Cright.">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20f%28x%29%3D%5Cleft%5C%7B%5Cbegin%7Bmatrix%7D%20%5Cfrac%7BC%7D%7Bx%5E2%7D%2C%20%26%20x%5Cgeq%2010%20%5C%5C%200%2C%20%26%20x%20%3C%2010%20%5Cend%7Bmatrix%7D%5Cright.">
 </p>
 
 for uma densidade, e encontre *P(x > 15)*.
@@ -306,23 +306,23 @@ for uma densidade, e encontre *P(x > 15)*.
 **Resolução:**
 
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20%5Cint_%7B-%5Cinfty%7D%5E%7B%5Cinfty%7Df%28x%29.dx%20%3D%20%5Cint_%7B-%5Cinfty%7D%5E%7B10%7D0.dx%20&plus;%20%5Cint_%7B10%7D%5E%7B%5Cinfty%7D%5Cfrac%7BC%7D%7Bx%5E2%7D.dx">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20%5Cint_%7B-%5Cinfty%7D%5E%7B%5Cinfty%7Df%28x%29.dx%20%3D%20%5Cint_%7B-%5Cinfty%7D%5E%7B10%7D0.dx%20&plus;%20%5Cint_%7B10%7D%5E%7B%5Cinfty%7D%5Cfrac%7BC%7D%7Bx%5E2%7D.dx">
 </p>
 
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20C%5Cint_%7B10%7D%5E%7B%5Cinfty%7Dx%5E%7B-2%7D%3D%20C%5Cleft%20%5B%20-2x%5E%7B-3%7D%20%5Cright%20%5D_%7B10%7D%5E%7B%5Cinfty%7D">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20C%5Cint_%7B10%7D%5E%7B%5Cinfty%7Dx%5E%7B-2%7D%3D%20C%5Cleft%20%5B%20-2x%5E%7B-3%7D%20%5Cright%20%5D_%7B10%7D%5E%7B%5Cinfty%7D">
 </p>
 
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20%5Cfrac%7BC%7D%7B10%7D%20%3D1%20%5CRightarrow%20C%20%3D%2010">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20%5Cfrac%7BC%7D%7B10%7D%20%3D1%20%5CRightarrow%20C%20%3D%2010">
 </p>
 
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20%5Ctherefore%20P%28x%20%3E%2015%29%20%3D%20%5Cint_%7B15%7D%5E%7B%5Cinfty%7D%5Cfrac%7B10%7D%7Bx%5E2%7D.dx%20%3D%2010.%5Cleft%20%5B%20%5Cfrac%7B1%7D%7Bx%7D%20%5Cright%20%5D_%7B15%7D%5E%7B%5Cinfty%7D">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20%5Ctherefore%20P%28x%20%3E%2015%29%20%3D%20%5Cint_%7B15%7D%5E%7B%5Cinfty%7D%5Cfrac%7B10%7D%7Bx%5E2%7D.dx%20%3D%2010.%5Cleft%20%5B%20%5Cfrac%7B1%7D%7Bx%7D%20%5Cright%20%5D_%7B15%7D%5E%7B%5Cinfty%7D">
 </p>
 
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28x%20%3E%2015%29%20%3D%20%5Cfrac%7B2%7D%7B3%7D">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28x%20%3E%2015%29%20%3D%20%5Cfrac%7B2%7D%7B3%7D">
 </p>
 
 ## Questão 9 
@@ -335,34 +335,34 @@ Um fabricante afirma que apenas 5% de todas as válvulas que produz têm duraç�
 **Resolução:**
 
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28v%29%20%3D%2095%5C%25">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28v%29%20%3D%2095%5C%25">
 </p>
 
   - Sendo *A* o evento *"o lote será aceito"*, temos:
   
   <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28A%29%20%3D%20P%28v%29.P%28A%7Cv%29%20%5CRightarrow%20P%28A%29%20%3D%200.95x0.90">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28A%29%20%3D%20P%28v%29.P%28A%7Cv%29%20%5CRightarrow%20P%28A%29%20%3D%200.95x0.90">
 </p>
 
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28A%29%20%3D%200.855">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28A%29%20%3D%200.855">
 </p>
 
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28%5Coverline%7BA%7D%29%20%3D%200.145">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28%5Coverline%7BA%7D%29%20%3D%200.145">
 </p>
 
   - Para encontrarmos a probabilidade esperada, vamos usar binomial:
   
   <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20%5Ctherefore%20P%28x%20%5Cgeq%202%29%20%3D%201%20-%20P%28x%20%3C%202%29">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20%5Ctherefore%20P%28x%20%5Cgeq%202%29%20%3D%201%20-%20P%28x%20%3C%202%29">
 </p>
 
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28x%20%5Cgeq%202%29%20%3D%201%20-%20%5Cleft%20%5B%20%5Cleft%20%28%200%2C95%20%5Cright%20%29%5E%7B10%7D%20&plus;%20%5Cbinom%7B10%7D%7B9%7D.%5Cleft%20%28%200.05%20%5Cright%20%29%5E1.%280.95%29%5E9%20%5Cright%20%5D">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28x%20%5Cgeq%202%29%20%3D%201%20-%20%5Cleft%20%5B%20%5Cleft%20%28%200%2C95%20%5Cright%20%29%5E%7B10%7D%20&plus;%20%5Cbinom%7B10%7D%7B9%7D.%5Cleft%20%28%200.05%20%5Cright%20%29%5E1.%280.95%29%5E9%20%5Cright%20%5D">
 </p>
 
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28x%20%5Cgeq%202%29%20%3D%200.086">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Csmall%20P%28x%20%5Cgeq%202%29%20%3D%200.086">
 </p>
   

--- a/probabilidade/resumos/medidasDeDispersao.md
+++ b/probabilidade/resumos/medidasDeDispersao.md
@@ -13,41 +13,41 @@ Feito com basse nesse [slide](https://www.dropbox.com/s/5byiyz93n9fr0gj/Aula%205
 ## Desvio médio
 Considere um conjunto de observações de uma variável *x*, dado por *x_{1}*, *x_{2}*, ..., *x_{k}* com respectivas frequências *n_{1}*, *n_{2}*, ..., *n_{k}*. Definimos o desvio médio de *x*, denotado por *dm(x)*, como sendo a medida:
 
-Considere um conjunto de observações de uma variável *x*, dado por ![](http://latex.codecogs.com/gif.latex?%5Cinline%20%5Cfn_cm%20%5Csmall%20x_%7B1%7D),  ![](http://latex.codecogs.com/gif.latex?%5Cinline%20%5Cfn_cm%20%5Csmall%20x_%7B2%7D), . . . , ![](http://latex.codecogs.com/gif.latex?%5Cinline%20%5Cfn_cm%20%5Csmall%20x_%7Bk%7D) com respectivas frequências ![](http://latex.codecogs.com/gif.latex?%5Cinline%20%5Cfn_cm%20%5Csmall%20n_%7B1%7D), ![](http://latex.codecogs.com/gif.latex?%5Cinline%20%5Cfn_cm%20%5Csmall%20n_%7B2%7D), . . . , ![](http://latex.codecogs.com/gif.latex?%5Cinline%20%5Cfn_cm%20%5Csmall%20n_%7Bk%7D). Definimos o desvio médio de *x*, denotado por *dm(x)*, como sendo a medida:
+Considere um conjunto de observações de uma variável *x*, dado por ![](https://latex.codecogs.com/gif.latex?%5Cinline%20%5Cfn_cm%20%5Csmall%20x_%7B1%7D),  ![](https://latex.codecogs.com/gif.latex?%5Cinline%20%5Cfn_cm%20%5Csmall%20x_%7B2%7D), . . . , ![](https://latex.codecogs.com/gif.latex?%5Cinline%20%5Cfn_cm%20%5Csmall%20x_%7Bk%7D) com respectivas frequências ![](https://latex.codecogs.com/gif.latex?%5Cinline%20%5Cfn_cm%20%5Csmall%20n_%7B1%7D), ![](https://latex.codecogs.com/gif.latex?%5Cinline%20%5Cfn_cm%20%5Csmall%20n_%7B2%7D), . . . , ![](https://latex.codecogs.com/gif.latex?%5Cinline%20%5Cfn_cm%20%5Csmall%20n_%7Bk%7D). Definimos o desvio médio de *x*, denotado por *dm(x)*, como sendo a medida:
 
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Clarge%20dm%28x%29%3D%5Cfrac%7B%5Csum_%7Bi%3D1%7D%5E%7Bk%7D%7Bn_%7Bi%7D%7Cx_%7Bi%7D-%5Coverline%7Bx%7D%7C%7D%7D%7Bn%7D">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Clarge%20dm%28x%29%3D%5Cfrac%7B%5Csum_%7Bi%3D1%7D%5E%7Bk%7D%7Bn_%7Bi%7D%7Cx_%7Bi%7D-%5Coverline%7Bx%7D%7C%7D%7D%7Bn%7D">
 </p>
 
 Equivalente, temos:
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Clarge%20dm%28x%29%3D%7B%5Csum_%7Bi%3D1%7D%5E%7Bk%7D%7Bf_%7Bi%7D%7Cx_%7Bi%7D-%5Coverline%7Bx%7D%7C%7D%7D">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Clarge%20dm%28x%29%3D%7B%5Csum_%7Bi%3D1%7D%5E%7Bk%7D%7Bf_%7Bi%7D%7Cx_%7Bi%7D-%5Coverline%7Bx%7D%7C%7D%7D">
 </p>
 
 
 ## Variância
-Considere um conjunto de observações de uma variável *x*, dado por ![](http://latex.codecogs.com/gif.latex?%5Cinline%20%5Cfn_cm%20%5Csmall%20x_%7B1%7D),  ![](http://latex.codecogs.com/gif.latex?%5Cinline%20%5Cfn_cm%20%5Csmall%20x_%7B2%7D), . . . , ![](http://latex.codecogs.com/gif.latex?%5Cinline%20%5Cfn_cm%20%5Csmall%20x_%7Bk%7D) com respectivas frequências ![](http://latex.codecogs.com/gif.latex?%5Cinline%20%5Cfn_cm%20%5Csmall%20n_%7B1%7D), ![](http://latex.codecogs.com/gif.latex?%5Cinline%20%5Cfn_cm%20%5Csmall%20n_%7B2%7D), . . . , ![](http://latex.codecogs.com/gif.latex?%5Cinline%20%5Cfn_cm%20%5Csmall%20n_%7Bk%7D). Definimos o variância de *x*, denotado por *var(x)*, como sendo a medida:
+Considere um conjunto de observações de uma variável *x*, dado por ![](https://latex.codecogs.com/gif.latex?%5Cinline%20%5Cfn_cm%20%5Csmall%20x_%7B1%7D),  ![](https://latex.codecogs.com/gif.latex?%5Cinline%20%5Cfn_cm%20%5Csmall%20x_%7B2%7D), . . . , ![](https://latex.codecogs.com/gif.latex?%5Cinline%20%5Cfn_cm%20%5Csmall%20x_%7Bk%7D) com respectivas frequências ![](https://latex.codecogs.com/gif.latex?%5Cinline%20%5Cfn_cm%20%5Csmall%20n_%7B1%7D), ![](https://latex.codecogs.com/gif.latex?%5Cinline%20%5Cfn_cm%20%5Csmall%20n_%7B2%7D), . . . , ![](https://latex.codecogs.com/gif.latex?%5Cinline%20%5Cfn_cm%20%5Csmall%20n_%7Bk%7D). Definimos o variância de *x*, denotado por *var(x)*, como sendo a medida:
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Clarge%20var%28x%29%3D%5Cfrac%7B%5Csum_%7Bi%3D1%7D%5E%7Bk%7Dn_%7Bi%7D%28x_%7Bi%7D-%5Cbar%7Bx%7D%29%5E2%7D%7Bn%7D">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Clarge%20var%28x%29%3D%5Cfrac%7B%5Csum_%7Bi%3D1%7D%5E%7Bk%7Dn_%7Bi%7D%28x_%7Bi%7D-%5Cbar%7Bx%7D%29%5E2%7D%7Bn%7D">
 </p>
 
 Equivalente, temos:
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Clarge%20var%28x%29%3D%7B%5Csum_%7Bi%3D1%7D%5E%7Bk%7Df_%7Bi%7D%28x_%7Bi%7D-%5Cbar%7Bx%7D%29%5E2%7D">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Clarge%20var%28x%29%3D%7B%5Csum_%7Bi%3D1%7D%5E%7Bk%7Df_%7Bi%7D%28x_%7Bi%7D-%5Cbar%7Bx%7D%29%5E2%7D">
 </p>
 
 O **desvio padrão** de *x*, *dp(x)*, é definido como:
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Clarge%20dp%28x%29%3D%5Csqrt%7Bvar%28x%29%7D">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Clarge%20dp%28x%29%3D%5Csqrt%7Bvar%28x%29%7D">
 </p>
 
 ## Coeficiente de variação
 É uma medida relativa de variabilidade. O seu valor é determinado por intermédio do quociente entre o desvio padrão e a média aritmética dos dados:
 
 <p align="center"> 
-  <img src="http://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Clarge%20Cv%28x%29%3D%5Cfrac%7Bdp%28x%29%7D%7B%5Cbar%7Bx%7D%7DX100">
+  <img src="https://latex.codecogs.com/gif.latex?%5Cfn_cm%20%5Clarge%20Cv%28x%29%3D%5Cfrac%7Bdp%28x%29%7D%7B%5Cbar%7Bx%7D%7DX100">
 </p>
 
   - Um critério de decisão sobre a representividade ou não da média, pode ser dada pela seguinte linha de corte:
-    - Se ![](http://latex.codecogs.com/gif.latex?%5Cdpi%7B100%7D%20%5Cfn_cm%20%5Csmall%20Cv%28x%29%5Cgeq%200.5) , a média **não** é representativa;
-    - Se ![](http://latex.codecogs.com/gif.latex?%5Cdpi%7B100%7D%20%5Cfn_cm%20%5Csmall%20Cv%28x%29%3C%200.5) , a média é representativa.
+    - Se ![](https://latex.codecogs.com/gif.latex?%5Cdpi%7B100%7D%20%5Cfn_cm%20%5Csmall%20Cv%28x%29%5Cgeq%200.5) , a média **não** é representativa;
+    - Se ![](https://latex.codecogs.com/gif.latex?%5Cdpi%7B100%7D%20%5Cfn_cm%20%5Csmall%20Cv%28x%29%3C%200.5) , a média é representativa.

--- a/so/resumos/primeiro_estagio.md
+++ b/so/resumos/primeiro_estagio.md
@@ -25,11 +25,11 @@ ao realizar o carregamento do Sistema Operacional. No linux, esse processo é ch
 - Na família de SO UNIX existe uma operação chamada **fork**. Essa operação clona o processo em dois. O
 resultado do fork no filho retorna 0 e no pai retorna o PID do filho.
 
-![imagem de fork](http://www.ppgia.pucpr.br/~laplima/ensino/so/materia/images/ps-fork.png)
+![imagem de fork](https://www.ppgia.pucpr.br/~laplima/ensino/so/materia/images/ps-fork.png)
 
 - Existem três principais estados para um processo: **Bloqueado, Rodando e Pronto para Rodar**.
 
-![estados de um processo](http://www.ppgia.pucpr.br/~laplima/ensino/so/materia/images/ps-estados.png)
+![estados de um processo](https://www.ppgia.pucpr.br/~laplima/ensino/so/materia/images/ps-estados.png)
 
 - **Escalonador** é responsável por realizar a troca de contexto entre os processos em execução.
 
@@ -142,5 +142,5 @@ sua execução.
  - Threads **NÃO** compartilham: seu PC, seu ponteiro de pilha, seu registrador, seus sinais pendentes e bloqueados,
  seus próprios dados e suas propriedades de escalonamento;
  
- ![memória de múltiplas threads](http://www.ppgia.pucpr.br/~laplima/ensino/so/materia/images/ps-modelo_threads.png)
+ ![memória de múltiplas threads](https://www.ppgia.pucpr.br/~laplima/ensino/so/materia/images/ps-modelo_threads.png)
  


### PR DESCRIPTION
No deploy do netlify, ele retorna um erro de mixed content quando adicionamos referências que não é **https**, isso é por questões de segurança e padrão

Troquei todos os links de conteúdo para **https**

- [X] Minha contribuição respeita o [código de conduta](https://github.com/OpenDevUFCG/Tamburetei/blob/master/CODE_OF_CONDUCT.md) do repositório.
- [X] Minha contribuição respeita as [restrições de upload](https://github.com/OpenDevUFCG/Tamburetei/wiki/Restrições-de-Upload) do repositório.
