### PR TITLE
Corrige aninhamento de tópicos

### DIFF
--- a/redes/resumos/camadaDeTransporte.md
+++ b/redes/resumos/camadaDeTransporte.md
@@ -2,313 +2,313 @@
 title: Camada de Transporte
 ---
 
-## Sum·rio
+## Sum√°rio
 - [Camada de Transporte](#camada-de-transporte)
-  - [Protocolos e serviÁos de transporte](#protocolos-e-serviÁos-de-transporte)
-  - [IdentificaÁ„o da aplicaÁ„o no host](#identificaÁ„o-da-aplicaÁ„o-no-host)
-  - [DemultiplexaÁ„o/MultiplexaÁ„o](#demultiplexaÁ„omultiplexaÁ„o)
+  - [Protocolos e servi√ßos de transporte](#protocolos-e-servi√ßos-de-transporte)
+  - [Identifica√ß√£o da aplica√ß√£o no host](#identifica√ß√£o-da-aplica√ß√£o-no-host)
+  - [Demultiplexa√ß√£o/Multiplexa√ß√£o](#demultiplexa√ß√£omultiplexa√ß√£o)
   - [UDP: User Datagram Protocol](#udp-user-datagram-protocol)
     - [UDP Checksum](#udp-checksum)
-  - [PrincÌpios de transferÍncia confi·vel de dados](#princÌpios-de-transferÍncia-confi·vel-de-dados)
-    - [TransferÍncia confi·vel usando um canal com erro de bits](#transferÍncia-confi·vel-usando-um-canal-com-erro-de-bits)
-    - [TransferÍncia confi·vel usando um canal com erro de bits e perdas](#transferÍncia-confi·vel-usando-um-canal-com-erro-de-bits-e-perdas)
-    - [EstratÈgias de Retransmiss„o](#estratÈgias-de-retransmiss„o)
+  - [Princ√≠pios de transfer√™ncia confi√°vel de dados](#princ√≠pios-de-transfer√™ncia-confi√°vel-de-dados)
+    - [Transfer√™ncia confi√°vel usando um canal com erro de bits](#transfer√™ncia-confi√°vel-usando-um-canal-com-erro-de-bits)
+    - [Transfer√™ncia confi√°vel usando um canal com erro de bits e perdas](#transfer√™ncia-confi√°vel-usando-um-canal-com-erro-de-bits-e-perdas)
+    - [Estrat√©gias de Retransmiss√£o](#estrat√©gias-de-retransmiss√£o)
   - [O Protocolo TCP](#o-protocolo-tcp)
     - [Estrutura do Segmento TCP](#estrutura-do-segmento-tcp)
-    - [N˙mero de SequÍncia e ACKs no TCP](#n˙mero-de-sequÍncia-e-acks-no-tcp)
-    - [TCP Round Trip Time e temporizaÁ„o](#tcp-round-trip-time-e-temporizaÁ„o)
-    - [TCP: transferÍncia de dados confi·vel](#tcp-transferÍncia-de-dados-confi·vel)
-    - [Retransmiss„o r·pida](#retransmiss„o-r·pida)
+    - [N√∫mero de Sequ√™ncia e ACKs no TCP](#n√∫mero-de-sequ√™ncia-e-acks-no-tcp)
+    - [TCP Round Trip Time e temporiza√ß√£o](#tcp-round-trip-time-e-temporiza√ß√£o)
+    - [TCP: transfer√™ncia de dados confi√°vel](#tcp-transfer√™ncia-de-dados-confi√°vel)
+    - [Retransmiss√£o r√°pida](#retransmiss√£o-r√°pida)
     - [TCP: controle de fluxo ](#tcp-controle-de-fluxo)
-    - [Gerenciamento de Conex„o](#gerenciamento-de-conex„o)
+    - [Gerenciamento de Conex√£o](#gerenciamento-de-conex√£o)
   - [Controle de congestionamento do TCP](#controle-de-congestionamento-do-tcp)
     - [Janela de Congestionamento](#janela-de-congestionamento)
     - [Janela do Receptor](#janela-do-receptor)
-    - [EvoluÁ„o de uma Conex„o TCP](#evoluÁ„o-de-uma-conex„o-tcp)
-    - [Duas Fases dessa EvoluÁ„o](#duas-fases-dessa-evoluÁ„o)
+    - [Evolu√ß√£o de uma Conex√£o TCP](#evolu√ß√£o-de-uma-conex√£o-tcp)
+    - [Duas Fases dessa Evolu√ß√£o](#duas-fases-dessa-evolu√ß√£o)
     - [E quando ocorrer um problema?](#e-quando-ocorrer-um-problema)
       - [Resumo](#resumo)
 
-Os serviÁos oferecidos pelo protocolo IP n„o oferecem confiabilidade. Problemas relacionados ‡ congestionamento, perda e ordenaÁ„o de pacotes n„o s„o tratados. Esse È um grande problema pois a camada de aplicaÁ„o necessita prover um serviÁo confi·vel na entrega de dados para os usu·rios. Para tal, a camada de transporte tem diversos protocolos e funÁıes para melhorar e corrigir erros das camadas abaixo da mesma - como a de redes.
+Os servi√ßos oferecidos pelo protocolo IP n√£o oferecem confiabilidade. Problemas relacionados √† congestionamento, perda e ordena√ß√£o de pacotes n√£o s√£o tratados. Esse √© um grande problema pois a camada de aplica√ß√£o necessita prover um servi√ßo confi√°vel na entrega de dados para os usu√°rios. Para tal, a camada de transporte tem diversos protocolos e fun√ß√µes para melhorar e corrigir erros das camadas abaixo da mesma - como a de redes.
 
-## Protocolos e serviÁos de transporte
+## Protocolos e servi√ßos de transporte
 
-* Fornecem comunicaÁ„o lÛgica entre processos de aplicaÁ„o em diferentes hospedeiros
-*	Os protocolos de transporte s„o executados nos sistemas finais 
-  *	**Lado emissor**: quebra as mensagens da aplicaÁ„o em segmentos e envia para a camada de rede
-  *	**Lado receptor**: remonta os 3 segmentos em mensagens e passa para a camada de aplicaÁ„o 
-*	H· mais de um protocolo de transporte disponÌvel para as aplicaÁıes e nem todas implementam o mesmo conjunto de serviÁos:
+* Fornecem comunica√ß√£o l√≥gica entre processos de aplica√ß√£o em diferentes hospedeiros
+*	Os protocolos de transporte s√£o executados nos sistemas finais 
+  *	**Lado emissor**: quebra as mensagens da aplica√ß√£o em segmentos e envia para a camada de rede
+  *	**Lado receptor**: remonta os 3 segmentos em mensagens e passa para a camada de aplica√ß√£o 
+*	H√° mais de um protocolo de transporte dispon√≠vel para as aplica√ß√µes e nem todas implementam o mesmo conjunto de servi√ßos:
   *	Internet: TCP e UDP
   *	TCP
-    *	Confi·vel: garante ordem de entrega
+    *	Confi√°vel: garante ordem de entrega
     *	Controle de Congestionamento
     *	Controle de Fluxo
-    *	Orientado ‡ conex„o
-*	UDP
-  *	N„o confi·vel: n„o garante ordem na entrega
-  *	Extens„o do melhor esforÁo do IP
-  *	Apenas multiplexaÁ„o
+    *	Orientado √† conex√£o
+  *	UDP
+    *	N√£o confi√°vel: n√£o garante ordem na entrega
+    *	Extens√£o do melhor esfor√ßo do IP
+    *	Apenas multiplexa√ß√£o
 
-## IdentificaÁ„o da aplicaÁ„o no host
+## Identifica√ß√£o da aplica√ß√£o no host
 
-A camada de transporte oferece ‡ camada de aplicaÁ„o a funÁ„o de endereÁamento, onde os serviÁos s„o identificados pela sua porta (HTTP-80, FTP-20/21Ö) e uma conex„o entre sua estaÁ„o e outro host È feita atravÈs de um socket (IP+PORTA).
+A camada de transporte oferece √† camada de aplica√ß√£o a fun√ß√£o de endere√ßamento, onde os servi√ßos s√£o identificados pela sua porta (HTTP-80, FTP-20/21‚Ä¶) e uma conex√£o entre sua esta√ß√£o e outro host √© feita atrav√©s de um socket (IP+PORTA).
 
-1.	**Como cada m·quina È identificada unicamente na Internet?** <br/> > *N˙mero IP*.
-2.	**Como a entidade de rede (IP) identifica qual o protocolo de transporte est· sendo utilizado?** <br/> > *Tipo de protocolo est· indicado no cabeÁalho IP*.
-3.	**Dentro do host, como a entidade de transporte identifica qual aplicaÁ„o est· sendo utilizada?** <br/> > *Cada aplicaÁ„o tem uma ìPortaî ˙nica no host. Porta È identificada no pacote IP*.
-4.	**Como uma aplicaÁ„o cliente sabe qual a porta de uma aplicaÁ„o servidora para poder enviar pacotes?** <br/> > *Alguns serviÁos tÍm n˙meros de portas j· convencionadas (portas ìbem conhecidasî)*.
+1.	**Como cada m√°quina √© identificada unicamente na Internet?** <br/> > *N√∫mero IP*.
+2.	**Como a entidade de rede (IP) identifica qual o protocolo de transporte est√° sendo utilizado?** <br/> > *Tipo de protocolo est√° indicado no cabe√ßalho IP*.
+3.	**Dentro do host, como a entidade de transporte identifica qual aplica√ß√£o est√° sendo utilizada?** <br/> > *Cada aplica√ß√£o tem uma ‚ÄúPorta‚Äù √∫nica no host. Porta √© identificada no pacote IP*.
+4.	**Como uma aplica√ß√£o cliente sabe qual a porta de uma aplica√ß√£o servidora para poder enviar pacotes?** <br/> > *Alguns servi√ßos t√™m n√∫meros de portas j√° convencionadas (portas ‚Äúbem conhecidas‚Äù)*.
 
-**N˙meros de portas**
+**N√∫meros de portas**
 
-**1-255**		  Reservadas para serviÁos padr„o portas ìbem conhecidasî.
+**1-255**		  Reservadas para servi√ßos padr√£o portas ‚Äúbem conhecidas‚Äù.
 
-**256-1023** 	Reservado para serviÁos Unix. 
+**256-1023** 	Reservado para servi√ßos Unix. 
 
-**1-1023** 		Somente podem ser usadas por super-usu·rio.
+**1-1023** 		Somente podem ser usadas por super-usu√°rio.
 
-**1024-4999** Usadas por processos de sistema e de usu·rio.
+**1024-4999** Usadas por processos de sistema e de usu√°rio.
 
-**5000-** 		Usadas somente por processos de usu·rio.
+**5000-** 		Usadas somente por processos de usu√°rio.
 
-## DemultiplexaÁ„o/MultiplexaÁ„o
+## Demultiplexa√ß√£o/Multiplexa√ß√£o
 
-*	**DemultiplexaÁ„o no hospedeiro receptor**:
+*	**Demultiplexa√ß√£o no hospedeiro receptor**:
   *	Entrega os segmentos recebidos ao socket correto
-*	**MultiplexaÁ„o no hospedeiro receptor**:
-  *	Coleta dados de m˙ltiplos sockets, envelopa os dado com cabeÁalho (usado depois para demultiplexaÁ„o). 
+*	**Multiplexa√ß√£o no hospedeiro receptor**:
+  *	Coleta dados de m√∫ltiplos sockets, envelopa os dado com cabe√ßalho (usado depois para demultiplexa√ß√£o). 
 
 *	**Computador recebe datagramas IP**
-  *	Cada datagrama possui endereÁo IP de origem e IP de destino 
+  *	Cada datagrama possui endere√ßo IP de origem e IP de destino 
   *	Cada datagrama carrega 1 segmento da camada de transporte
-  *	Cada segmento possui n˙meros de porta de origem e destino (lembre-se: n˙meros de porta bem conhecidos para aplicaÁıes especÌficas)
-  *	O hospedeiro usa endereÁos IP e n˙meros de porta para direcionar o segmento ao socket apropriado.
+  *	Cada segmento possui n√∫meros de porta de origem e destino (lembre-se: n√∫meros de porta bem conhecidos para aplica√ß√µes espec√≠ficas)
+  *	O hospedeiro usa endere√ßos IP e n√∫meros de porta para direcionar o segmento ao socket apropriado.
 
 *	**UDP**:
-*	**Socket UDP** identificado por dois valores: (endereÁo IP de destino, n˙mero da porta de destino)
+*	**Socket UDP** identificado por dois valores: (endere√ßo IP de destino, n√∫mero da porta de destino)
   *	Quando o hospedeiro recebe o segmento UDP: 
-    *	Verifica o n˙mero da porta de destino no segmento
-    *	Direciona o segmento UDP para o socket com este n˙mero de porta 
-  *	Datagramas com IP de origem diferentes e/ou portas de origem diferentes s„o direcionados para o mesmo socket.
+    *	Verifica o n√∫mero da porta de destino no segmento
+    *	Direciona o segmento UDP para o socket com este n√∫mero de porta 
+  *	Datagramas com IP de origem diferentes e/ou portas de origem diferentes s√£o direcionados para o mesmo socket.
 
 *	**TCP**:
 *	**Socket TCP** identificado por 4 valores: 
-  *	EndereÁo IP de origem
-  *	EndereÁo porta de origem 
-  *	EndereÁo IP de destino
-  *	EndereÁo porta de destino
+  *	Endere√ßo IP de origem
+  *	Endere√ßo porta de origem 
+  *	Endere√ßo IP de destino
+  *	Endere√ßo porta de destino
 * Hospedeiro receptor usa os quatro valores para direcionar o segmento ao socket apropriado 
-* Hospedeiro servidor pode suportar v·rios sockets TCP simult‚neos:
-  *	Cada socket È identificado pelos seus prÛprios 4 valores
+* Hospedeiro servidor pode suportar v√°rios sockets TCP simult√¢neos:
+  *	Cada socket √© identificado pelos seus pr√≥prios 4 valores
   *	Servidores possuem sockets diferentes para cada cliente conectado.
 
 ## UDP: User Datagram Protocol
 
-O UDP È um protocolo da camada de transporte n„o confi·vel e n„o-orientado ‡ conex„o. Fornece apenas os serviÁos de endereÁamento e fragmentaÁ„o, n„o provendo confiabilidade (controle de fluxo, erro, congestionamento). Isso indica que o UDP n„o adiciona serviÁos ao protocolo IP. O que nos leva ent„o a utilizar o UDP?
+O UDP √© um protocolo da camada de transporte n√£o confi√°vel e n√£o-orientado √† conex√£o. Fornece apenas os servi√ßos de endere√ßamento e fragmenta√ß√£o, n√£o provendo confiabilidade (controle de fluxo, erro, congestionamento). Isso indica que o UDP n√£o adiciona servi√ßos ao protocolo IP. O que nos leva ent√£o a utilizar o UDP?
 
-O UDP por ser mais simples possui um cabeÁalho menor gerando um menor overhead. Ideal para algumas aplicaÁıes onde a velocidade È mais ˙til que a confiabilidade como aplicaÁıes multimÌdia. Afinal n„o faz sentido algum receber um trecho de um arquivo m˙sica que j· passou.
+O UDP por ser mais simples possui um cabe√ßalho menor gerando um menor overhead. Ideal para algumas aplica√ß√µes onde a velocidade √© mais √∫til que a confiabilidade como aplica√ß√µes multim√≠dia. Afinal n√£o faz sentido algum receber um trecho de um arquivo m√∫sica que j√° passou.
 
-AlÈm de aplicaÁıes multimÌdia, o UDP È utilizado tambÈm pelo TFTP (Trivial File Transfer Protocol), RIP (Routing Information Protocol), SNMP (Simple Network Management Protocol) e DNS (Domain Name System).
+Al√©m de aplica√ß√µes multim√≠dia, o UDP √© utilizado tamb√©m pelo TFTP (Trivial File Transfer Protocol), RIP (Routing Information Protocol), SNMP (Simple Network Management Protocol) e DNS (Domain Name System).
 
-*	ServiÁo ìbest effortî, segmentos **UDP** podem ser:
-  *	**Perdidos** ou **Entregues** fora de ordem para a aplicaÁ„o
-*	Sem conex„o:
-  *	N„o h· apresentaÁ„o entre o **UDP** transmissor e o receptor.
-  *	Cada segmento UDP È tratado de forma independente dos outros.
+*	Servi√ßo ‚Äúbest effort‚Äù, segmentos **UDP** podem ser:
+  *	**Perdidos** ou **Entregues** fora de ordem para a aplica√ß√£o
+*	Sem conex√£o:
+  *	N√£o h√° apresenta√ß√£o entre o **UDP** transmissor e o receptor.
+  *	Cada segmento UDP √© tratado de forma independente dos outros.
 *	Por que existe um **UDP**?
-  *	N„o h· estabelecimento de conex„o (que possa resultar em atrasos).
-  *	Simples: n„o h· estado de conex„o nem no transmissor, nem no receptor.
-  *	CabeÁalho de segmento reduzido.
-  *	N„o h· controle de congestionamento: **UDP** pode enviar segmentos t„o r·pido quanto desejado (e possÌvel).
-  *	Muito usado por aplicaÁıes de multimÌdia contÌnua (streaming) **UDP**:
-  *	Tolerantes ‡ perda.
-  *	SensÌveis ‡ taxa.
-  *	TransferÍncia confi·vel sobre **UDP**: acrescentar confiabilidade na camada de aplicaÁ„o
-  *	RecuperaÁ„o de erro especÌfica de cada aplicaÁ„o.
+  *	N√£o h√° estabelecimento de conex√£o (que possa resultar em atrasos).
+  *	Simples: n√£o h√° estado de conex√£o nem no transmissor, nem no receptor.
+  *	Cabe√ßalho de segmento reduzido.
+  *	N√£o h√° controle de congestionamento: **UDP** pode enviar segmentos t√£o r√°pido quanto desejado (e poss√≠vel).
+  *	Muito usado por aplica√ß√µes de multim√≠dia cont√≠nua (streaming) **UDP**:
+  *	Tolerantes √† perda.
+  *	Sens√≠veis √† taxa.
+  *	Transfer√™ncia confi√°vel sobre **UDP**: acrescentar confiabilidade na camada de aplica√ß√£o
+  *	Recupera√ß√£o de erro espec√≠fica de cada aplica√ß√£o.
 
 ### UDP Checksum
 
-Objetivo: detectar ìerrosî (ex.: bits trocados) no segmento transmitido
+Objetivo: detectar ‚Äúerros‚Äù (ex.: bits trocados) no segmento transmitido
 
 *	**Transmissor**:
-  *	Trata o conte˙do do segmento como sequÍncia de inteiros de 16 bits 
-  *	Checksum: soma (complemento de 1 da soma) do conte˙do do segmento 
+  *	Trata o conte√∫do do segmento como sequ√™ncia de inteiros de 16 bits 
+  *	Checksum: soma (complemento de 1 da soma) do conte√∫do do segmento 
   *	Transmissor coloca o valor do checksum no campo de checksum do UDP 
 *	**Receptor**:
   *	Computa o checksum do segmento recebido
-  *	Verifica se o checksum calculado È igual ao valor do campo checksum:
-  * N√O - erro detectado
-  *	SIM - n„o h· erros. Mas talvez haja erros apesar disso? Mas depoisÖ
+  *	Verifica se o checksum calculado √© igual ao valor do campo checksum:
+  * N√ÉO - erro detectado
+  *	SIM - n√£o h√° erros. Mas talvez haja erros apesar disso? Mas depois‚Ä¶
 
-## PrincÌpios de transferÍncia confi·vel de dados
+## Princ√≠pios de transfer√™ncia confi√°vel de dados
 
-Importante nas camadas de aplicaÁ„o, transporte e enlace. CaracterÌsticas dos canais n„o confi·veis determinar„o a complexidade dos protocolos confi·veis de transferÍncia de dados (rdt).
+Importante nas camadas de aplica√ß√£o, transporte e enlace. Caracter√≠sticas dos canais n√£o confi√°veis determinar√£o a complexidade dos protocolos confi√°veis de transfer√™ncia de dados (rdt).
 
-### TransferÍncia confi·vel usando um canal com erro de bits
+### Transfer√™ncia confi√°vel usando um canal com erro de bits
 *	Canal subjacente pode trocar valores dos bits num pacote
   *	Checksum para detectar erros de bits
-*	A quest„o: como recuperar esses erros:
+*	A quest√£o: como recuperar esses erros:
   *	**Reconhecimentos** (**ACKs**): receptor avisa explicitamente ao transmissor que o pacote foi recebido corretamente 
   *	**Reconhecimentos negativos** (**NAKs**): receptor avisa explicitamente ao transmissor que o pacote tem erros 
-  *	Transmissor reenvia o pacote quando da recepÁ„o de um NAK
-*	Mecanismos necess·rios: 
-  *	DetecÁ„o de erros
+  *	Transmissor reenvia o pacote quando da recep√ß√£o de um NAK
+*	Mecanismos necess√°rios: 
+  *	Detec√ß√£o de erros
   *	Retorno do receptor: mensagens de controle 
   *	(ACK, NAK) rcvr->sender
 
-### TransferÍncia confi·vel usando um canal com erro de bits e perdas
+### Transfer√™ncia confi√°vel usando um canal com erro de bits e perdas
 
-O que acontece se o **ACK/NAK** È corrompido ou perdido? 
+O que acontece se o **ACK/NAK** √© corrompido ou perdido? 
 
-*	Transmissor n„o sabe o que aconteceu no receptor!
-*	Transmissor deve esperar durante um tempo razo·vel pelo ACK e se n„o recebÍ-lo deve retransmitir a informaÁ„o
-*	N„o pode apenas retransmitir: possÌvel duplicata 
+*	Transmissor n√£o sabe o que aconteceu no receptor!
+*	Transmissor deve esperar durante um tempo razo√°vel pelo ACK e se n√£o receb√™-lo deve retransmitir a informa√ß√£o
+*	N√£o pode apenas retransmitir: poss√≠vel duplicata 
 
 Tratando duplicatas: 
 
-*	Transmissor acrescenta n˙mero de seq¸Íncia em cada pacote
-*	Transmissor reenvia o ˙ltimo pacote se ACK/NAK for perdido
-*	Receptor descarta (n„o passa para a aplicaÁ„o) pacotes duplicados.
+*	Transmissor acrescenta n√∫mero de seq√º√™ncia em cada pacote
+*	Transmissor reenvia o √∫ltimo pacote se ACK/NAK for perdido
+*	Receptor descarta (n√£o passa para a aplica√ß√£o) pacotes duplicados.
 	
-###	EstratÈgias de Retransmiss„o
+###	Estrat√©gias de Retransmiss√£o
 
 *	Conhecidos como algoritmos ou protocolos Automatic Repeat Request (**ARQ**)
-*	Questıes de projeto:
-  *	Como o receptor requisita uma retransmiss„o?
+*	Quest√µes de projeto:
+  *	Como o receptor requisita uma retransmiss√£o?
   *	Como a fonte sabe quando retransmitir?
-*	Desempenho e exatid„o
-*	Para simplificar as explicaÁıes assumimos comunicaÁıes do tipo ponto-a-ponto
-*	Mesmas soluÁıes adotadas pela camada de enlace:
-  *	VerificaÁ„o de erros (checksum)
-  *	Retransmiss„o
-  *	TemporizaÁ„o
-  *	N˙mero de sequÍncia
+*	Desempenho e exatid√£o
+*	Para simplificar as explica√ß√µes assumimos comunica√ß√µes do tipo ponto-a-ponto
+*	Mesmas solu√ß√µes adotadas pela camada de enlace:
+  *	Verifica√ß√£o de erros (checksum)
+  *	Retransmiss√£o
+  *	Temporiza√ß√£o
+  *	N√∫mero de sequ√™ncia
   *	Pipelining
   *	Janela deslizante
 
 ## O Protocolo TCP
 
-O TCP È o protocolo da camada de transporte da arquitetura Internet respons·vel em oferecer confiabilidade na transmiss„o. O TCP fornece um **serviÁo orientado ‡ conex„o, confi·vel e full-duplex** para os serviÁos de aplicaÁ„o. 
+O TCP √© o protocolo da camada de transporte da arquitetura Internet respons√°vel em oferecer confiabilidade na transmiss√£o. O TCP fornece um **servi√ßo orientado √† conex√£o, confi√°vel e full-duplex** para os servi√ßos de aplica√ß√£o. 
 
-O TCP È **orientado a conex„o** ñ Para ter o controle dos pacotes enviados e conseguir efetuar a fragmentaÁ„o, o TCP precisa que os usu·rios finais tenham o controle do que est· sendo enviado. O protocolo TCP especifica trÍs fases durante uma conex„o: estabelecimento da ligaÁ„o, transferÍncia e tÈrmino de ligaÁ„o. Para estabelecimento da conex„o o TCP necessita que:
+O TCP √© **orientado a conex√£o** ‚Äì Para ter o controle dos pacotes enviados e conseguir efetuar a fragmenta√ß√£o, o TCP precisa que os usu√°rios finais tenham o controle do que est√° sendo enviado. O protocolo TCP especifica tr√™s fases durante uma conex√£o: estabelecimento da liga√ß√£o, transfer√™ncia e t√©rmino de liga√ß√£o. Para estabelecimento da conex√£o o TCP necessita que:
 
-> *ìO cliente inicia a ligaÁ„o enviando um pacote TCP com a flag SYN activa e espera-se que o servidor aceite a ligaÁ„o enviando um pacote SYN+ACK. Se, durante um determinado espaÁo de tempo, esse pacote n„o for recebido ocorre um timeout e o pacote SYN È reenviado. O estabelecimento da ligaÁ„o È concluÌdo por parte do cliente, confirmando a aceitaÁ„o do servidor respondendo-lhe com um pacote ACKî.*
+> *‚ÄúO cliente inicia a liga√ß√£o enviando um pacote TCP com a flag SYN activa e espera-se que o servidor aceite a liga√ß√£o enviando um pacote SYN+ACK. Se, durante um determinado espa√ßo de tempo, esse pacote n√£o for recebido ocorre um timeout e o pacote SYN √© reenviado. O estabelecimento da liga√ß√£o √© conclu√≠do por parte do cliente, confirmando a aceita√ß√£o do servidor respondendo-lhe com um pacote ACK‚Äù.*
 
-Efetua desconex„o ìsuaveî (**Graceful Connection Shutdown**) ñ O TCP sÛ encerra a conex„o depois de entregar os dados ao receptor.
+Efetua desconex√£o ‚Äúsuave‚Äù (**Graceful Connection Shutdown**) ‚Äì O TCP s√≥ encerra a conex√£o depois de entregar os dados ao receptor.
 
-O **TCP È Full-duplex** - … possÌvel a transferÍncia simult‚nea nas duas direÁıes durante a sess„o.
+O **TCP √© Full-duplex** - √â poss√≠vel a transfer√™ncia simult√¢nea nas duas dire√ß√µes durante a sess√£o.
 
-Utiliza o conceito de stream ñ O TCP envia uma **sequÍncia limitada e contÌnua de bytes** sem noÁ„o dos registros ou quantidade de pacotes que ser„o recebidos.
+Utiliza o conceito de stream ‚Äì O TCP envia uma **sequ√™ncia limitada e cont√≠nua de bytes** sem no√ß√£o dos registros ou quantidade de pacotes que ser√£o recebidos.
 
-Enxerga a rede como uma conex„o **ponto-a-ponto** ñ O protocolo TCP fornece uma conex„o diretamente entre aplicativos dos hosts. Tal conex„o È denominada conex„o virtual ponto-a-ponto, entre o transmissor e receptor, os dispositivos de rede (roteadores) n„o enxergam a camada de transporte.
+Enxerga a rede como uma conex√£o **ponto-a-ponto** ‚Äì O protocolo TCP fornece uma conex√£o diretamente entre aplicativos dos hosts. Tal conex√£o √© denominada conex√£o virtual ponto-a-ponto, entre o transmissor e receptor, os dispositivos de rede (roteadores) n√£o enxergam a camada de transporte.
 
-O TCP permite a camada de aplicaÁ„o enxergar a rede como uma conex„o virtual.
+O TCP permite a camada de aplica√ß√£o enxergar a rede como uma conex√£o virtual.
 
 ### Estrutura do Segmento TCP
 
 ![Segmento TCP](https://i.imgur.com/XzbDQQC.png)
 
-### N˙mero de SequÍncia e ACKs no TCP
+### N√∫mero de Sequ√™ncia e ACKs no TCP
 
-*	N˙meros de seq¸Íncia:
-  *	N˙mero do primeiro byte nos segmentos de dados 
+*	N√∫meros de seq√º√™ncia:
+  *	N√∫mero do primeiro byte nos segmentos de dados 
 *	ACKs: 
-  *	N˙mero do prÛximo byte esperado do outro lado
+  *	N√∫mero do pr√≥ximo byte esperado do outro lado
   *	ACK cumulativo 
 
-![SequÍncia ACKs](https://i.imgur.com/Rt5TuBY.png)
+![Sequ√™ncia ACKs](https://i.imgur.com/Rt5TuBY.png)
 
-1.	**Como o receptor trata segmentos fora de ordem?** <br/> > *A especificaÁ„o do TCP n„o define, fica a critÈrio do implementador*.
+1.	**Como o receptor trata segmentos fora de ordem?** <br/> > *A especifica√ß√£o do TCP n√£o define, fica a crit√©rio do implementador*.
 
-### TCP Round Trip Time e temporizaÁ„o
+### TCP Round Trip Time e temporiza√ß√£o
 
-1.	**Como escolher o valor da temporizaÁ„o do TCP?**
+1.	**Como escolher o valor da temporiza√ß√£o do TCP?**
 
 * **Maior que o RTT**
   *	*Nota: RTT varia*
-*	**Muito curto**: *temporizaÁ„o prematura*
-  *	*Retransmissıes desnecess·rias*
-*	**Muito longo**: *a reaÁ„o ‡ perda de segmento fica lenta*
+*	**Muito curto**: *temporiza√ß√£o prematura*
+  *	*Retransmiss√µes desnecess√°rias*
+*	**Muito longo**: *a rea√ß√£o √† perda de segmento fica lenta*
 
 2.	**Como estimar o RTT?**
 
-*	**SampleRTT**: *tempo medido da transmiss„o de um segmento atÈ a respectiva confirmaÁ„o*
-  *	*Ignora retransmissıes e segmentos reconhecidos de forma cumulativa**
-*	**SampleRTT** varia de forma r·pida, È desej·vel um amortecedor para a estimativa do RTT
-  *	*Usar v·rias medidas recentes, n„o apenas o ˙ltimo SampleRTT obtido*
+*	**SampleRTT**: *tempo medido da transmiss√£o de um segmento at√© a respectiva confirma√ß√£o*
+  *	*Ignora retransmiss√µes e segmentos reconhecidos de forma cumulativa**
+*	**SampleRTT** varia de forma r√°pida, √© desej√°vel um amortecedor para a estimativa do RTT
+  *	*Usar v√°rias medidas recentes, n√£o apenas o √∫ltimo SampleRTT obtido*
 
 ![TCP Round Trip](https://i.imgur.com/undkKLN.png)
 
-### TCP: transferÍncia de dados confi·vel
+### TCP: transfer√™ncia de dados confi√°vel
 
-*	TCP cria serviÁos de transferÍncia confi·vel de dados em cima do serviÁo n„o-confi·vel do IP TCP: serviÁo n„o-confi·vel do IP.
-*	Transmiss„o de v·rios segmentos em paralelo (Pipelined segments)
+*	TCP cria servi√ßos de transfer√™ncia confi√°vel de dados em cima do servi√ßo n√£o-confi√°vel do IP TCP: servi√ßo n√£o-confi√°vel do IP.
+*	Transmiss√£o de v√°rios segmentos em paralelo (Pipelined segments)
 *	ACKs cumulativos
-*	TCP usa tempo de retransmiss„o simples
-  *	Retransmissıes s„o disparadas por:
-    *	Eventos de tempo de confirmaÁ„o 
+*	TCP usa tempo de retransmiss√£o simples
+  *	Retransmiss√µes s√£o disparadas por:
+    *	Eventos de tempo de confirma√ß√£o 
     *	ACKs duplicados
-*	GeraÁ„o de ACK
+*	Gera√ß√£o de ACK
 
-**Evento no receptor** | **AÁ„o do receptor TCP** 
+**Evento no receptor** | **A√ß√£o do receptor TCP** 
 :---: | :---: 
- Segmento chega em ordem, n„o h· lacunas, segmentos anteriores j· aceitos | ACK retardado. Espera atÈ 500 ms pelo prÛximo segmento. Se n„o chegar, envia ACK 
- Segmento chega em ordem, n„o h· lacunas, um ACK atrasado pendente | Imediatamente envia um ACK cumulativo 
- Segmento chega fora de ordem, n˙mero de sequÍncia chegou maior: gap detectado | Envia ACK duplicado, indicando n˙mero de sequÍncia do prÛximo byte esperando
- Chegada de segmento parcial ou completamente preenche o gap | Reconhece imediatamente se o segmento comeÁa na borda inferior do gap
+ Segmento chega em ordem, n√£o h√° lacunas, segmentos anteriores j√° aceitos | ACK retardado. Espera at√© 500 ms pelo pr√≥ximo segmento. Se n√£o chegar, envia ACK 
+ Segmento chega em ordem, n√£o h√° lacunas, um ACK atrasado pendente | Imediatamente envia um ACK cumulativo 
+ Segmento chega fora de ordem, n√∫mero de sequ√™ncia chegou maior: gap detectado | Envia ACK duplicado, indicando n√∫mero de sequ√™ncia do pr√≥ximo byte esperando
+ Chegada de segmento parcial ou completamente preenche o gap | Reconhece imediatamente se o segmento come√ßa na borda inferior do gap
  
-### Retransmiss„o r·pida
+### Retransmiss√£o r√°pida
 
-*	Com frequÍncia, o tempo de expiraÁ„o È relativamente longo: 
+*	Com frequ√™ncia, o tempo de expira√ß√£o √© relativamente longo: 
   *	Longo atraso antes de reenviar um pacote perdido 
 *	Detecta segmentos perdidos por meio de ACKs duplicados
   *	Transmissor frequentemente envia muitos segmentos
-  *	Se o segmento È perdido, haver· muitos ACKs duplicados
-*	Se o transmissor recebe 3 ACKs para o mesmo dado, ele supıe que o segmento apÛs o dado confirmado foi perdido:
-  *	Retransmiss„o r·pida: reenvia o segmento antes de o temporizador expirar
+  *	Se o segmento √© perdido, haver√° muitos ACKs duplicados
+*	Se o transmissor recebe 3 ACKs para o mesmo dado, ele sup√µe que o segmento ap√≥s o dado confirmado foi perdido:
+  *	Retransmiss√£o r√°pida: reenvia o segmento antes de o temporizador expirar
 
 ### TCP: controle de fluxo 
 
-Controle de Fluxo (buffers e janelas de transmiss„o) ñ Um problema no mundo das redes È garantir o controle de fluxo entre usu·rios finais. A imprevisibilidade do tr·fego È o maior problema. Imagine o resultado do ENEM publicado na internet. Diversos usu·rios ir„o fazer requisiÁıes em pouco tempo podendo ser mais r·pido do que a entrega do servidor web. Assim diversas requisiÁıes ser„o novamente realizadas, gerando ainda mais tr·fego e pacotes duplicados. DaÌ o TCP utiliza o conceito de buffers (armazenamento de pedidos e respostas) e janelas deslizantes:
+Controle de Fluxo (buffers e janelas de transmiss√£o) ‚Äì Um problema no mundo das redes √© garantir o controle de fluxo entre usu√°rios finais. A imprevisibilidade do tr√°fego √© o maior problema. Imagine o resultado do ENEM publicado na internet. Diversos usu√°rios ir√£o fazer requisi√ß√µes em pouco tempo podendo ser mais r√°pido do que a entrega do servidor web. Assim diversas requisi√ß√µes ser√£o novamente realizadas, gerando ainda mais tr√°fego e pacotes duplicados. Da√≠ o TCP utiliza o conceito de buffers (armazenamento de pedidos e respostas) e janelas deslizantes:
 
-* Janela deslizante È uma caracterÌstica de alguns protocolos que permite que o remetente transmita mais que um pacote de dados antes de receber uma confirmaÁ„o. Depois de recebÍ-lo para o primeiro pacote enviado, o remetente desliza a janela do pacote e manda outra confirmaÁ„o. O n˙mero de pacotes transmitidos sem confirmaÁ„o È conhecido como o tamanho da janela; aumentando o tamanho da janela melhora-se a vaz„o.
-* O receptor da conex„o TCP possui um buffer de recepÁ„o:
-  *	Receptor informa a ·rea disponÌvel incluindo valor RcvWindow nos segmentos. 
-  *	Transmissor limita os dados n„o confinados ao RcvWindow.
+* Janela deslizante √© uma caracter√≠stica de alguns protocolos que permite que o remetente transmita mais que um pacote de dados antes de receber uma confirma√ß√£o. Depois de receb√™-lo para o primeiro pacote enviado, o remetente desliza a janela do pacote e manda outra confirma√ß√£o. O n√∫mero de pacotes transmitidos sem confirma√ß√£o √© conhecido como o tamanho da janela; aumentando o tamanho da janela melhora-se a vaz√£o.
+* O receptor da conex√£o TCP possui um buffer de recep√ß√£o:
+  *	Receptor informa a √°rea dispon√≠vel incluindo valor RcvWindow nos segmentos. 
+  *	Transmissor limita os dados n√£o confinados ao RcvWindow.
   *	Garantia contra overflow no buffer do receptor.
 
-Processos de aplicaÁ„o podem ser lentos para ler o buffer.
+Processos de aplica√ß√£o podem ser lentos para ler o buffer.
 
-O transmissor n„o deve esgotar os buffers de recepÁ„o enviando dados r·pido demais. ServiÁo de speed-matching: encontra a taxa de envio adequada ‡ taxa de vaz„o da aplicaÁ„o receptora.
+O transmissor n√£o deve esgotar os buffers de recep√ß√£o enviando dados r√°pido demais. Servi√ßo de speed-matching: encontra a taxa de envio adequada √† taxa de vaz√£o da aplica√ß√£o receptora.
 
 ![RcvBuffer](https://imgur.com/hmxgAVf.png)
 
-### Gerenciamento de Conex„o
+### Gerenciamento de Conex√£o
 
-*	**Estabelecimento de Conex„o**
+*	**Estabelecimento de Conex√£o**
   *	Protocolo
-    *	Passo 1: o cliente envia um segmento SYN especificando a porta do servidor ao qual deseja se conectar e seu n˙mero de sequÍncia inicial
-    *	Passo 2: o servidor responde enviando outro segmento SYN com o ACK do segmento recebido e o seu prÛprio n˙mero de sequÍncia 
-    *	Passo 3: o cliente retorna um ACK e a conex„o se estabelece
-  *	O tamanho m·ximo de segmento (MSS) que cada lado se propıe a aceitar tambÈm È definido no momento do estabelecimento da conex„o Pode acontecer um ìhalf openî
+    *	Passo 1: o cliente envia um segmento SYN especificando a porta do servidor ao qual deseja se conectar e seu n√∫mero de sequ√™ncia inicial
+    *	Passo 2: o servidor responde enviando outro segmento SYN com o ACK do segmento recebido e o seu pr√≥prio n√∫mero de sequ√™ncia 
+    *	Passo 3: o cliente retorna um ACK e a conex√£o se estabelece
+  *	O tamanho m√°ximo de segmento (MSS) que cada lado se prop√µe a aceitar tamb√©m √© definido no momento do estabelecimento da conex√£o Pode acontecer um ‚Äúhalf open‚Äù
 *	**Como funciona: (THREE-WAY-HANDSHAKE)**
   * 1.	Status: LISTENING 
-  * 2.	Status: SYN_RECV (Conex„o solicitada pelo cliente)
-  * 3.	Status: SYN_RECV (Servidor aloca recursos (memÛria) para a ìpotencialî conex„o e liga o relÛgio de TIMEOUT)
-  * 4.	Status: ESTABILISHED (Cliente confirma o pedido de conex„o e inicia envio de dados.)
-*	**TÈrmino de Conex„o**
-	* Cada direÁ„o da conex„o È encerrada independentemente.
+  * 2.	Status: SYN_RECV (Conex√£o solicitada pelo cliente)
+  * 3.	Status: SYN_RECV (Servidor aloca recursos (mem√≥ria) para a ‚Äúpotencial‚Äù conex√£o e liga o rel√≥gio de TIMEOUT)
+  * 4.	Status: ESTABILISHED (Cliente confirma o pedido de conex√£o e inicia envio de dados.)
+*	**T√©rmino de Conex√£o**
+	* Cada dire√ß√£o da conex√£o √© encerrada independentemente.
     *	Protocolo
       *	Passo 1: o cliente enviar um segmento FIN
       *	Passo 2: o servidor retorna um FIN e um ACK para o cliente
-      *	Passo 3: o cliente enviar um ACK e a conex„o se encerra.
-    *	… possÌvel efetuar um ìhalf-closeî mantendo-se apenas uma conex„o simplex.
+      *	Passo 3: o cliente enviar um ACK e a conex√£o se encerra.
+    *	√â poss√≠vel efetuar um ‚Äúhalf-close‚Äù mantendo-se apenas uma conex√£o simplex.
 
-![GerÍnciamento da Conex„o](https://imgur.com/dC8am8F.png)
+![Ger√™nciamento da Conex√£o](https://imgur.com/dC8am8F.png)
 
 ## Controle de congestionamento do TCP
 
 
-O controle È feito atravÈs de duas vari·veis adicionadas em cada lado da conex„o: adicionadas em cada lado da conex„o:
+O controle √© feito atrav√©s de duas vari√°veis adicionadas em cada lado da conex√£o: adicionadas em cada lado da conex√£o:
 
 *	**Janela de Congestionamento**
 *	**Limiar**
@@ -316,58 +316,58 @@ O controle È feito atravÈs de duas vari·veis adicionadas em cada lado da conex„o
 
 ### Janela de Congestionamento 
 
-*	Uma conex„o TCP controla sua taxa de transmiss„o limitando o seu n˙mero de segmentos que podem ser limitando o seu n˙mero de segmentos que podem ser transmitidos sem que uma confirmaÁ„o seja recebida
-  *	Esse n˙mero È chamado o tamanho da janela do TCP (w)
-*	Uma conex„o TCP comeÁa com um pequeno valor de w e ent„o o incrementa arriscando que exista mais largura de banda disponÌvel 
-*	Isso continua a ocorrer **atÈ que algum segmento seja perdido**
-*	Nesse momento, a conex„o TCP reduz **w** para um valor seguro, e ent„o continua a arriscar o crescimento
+*	Uma conex√£o TCP controla sua taxa de transmiss√£o limitando o seu n√∫mero de segmentos que podem ser limitando o seu n√∫mero de segmentos que podem ser transmitidos sem que uma confirma√ß√£o seja recebida
+  *	Esse n√∫mero √© chamado o tamanho da janela do TCP (w)
+*	Uma conex√£o TCP come√ßa com um pequeno valor de w e ent√£o o incrementa arriscando que exista mais largura de banda dispon√≠vel 
+*	Isso continua a ocorrer **at√© que algum segmento seja perdido**
+*	Nesse momento, a conex√£o TCP reduz **w** para um valor seguro, e ent√£o continua a arriscar o crescimento
 
 ### Janela do Receptor 
 
-O n˙mero m·ximo de segmentos n„o-confirmados È dado pelo mÌnimo entre os tamanhos das janelas È dado pelo mÌnimo entre os tamanhos das janelas de congestionamento e do receptor. Ou seja, mesmo que haja mais largura de banda, o receptor tambÈm pode ser um gargalo.
+O n√∫mero m√°ximo de segmentos n√£o-confirmados √© dado pelo m√≠nimo entre os tamanhos das janelas √© dado pelo m√≠nimo entre os tamanhos das janelas de congestionamento e do receptor. Ou seja, mesmo que haja mais largura de banda, o receptor tamb√©m pode ser um gargalo.
 
-### EvoluÁ„o de uma Conex„o TCP 
+### Evolu√ß√£o de uma Conex√£o TCP 
 
-No inÌcio, a janela de congestionamento tem o tamanho de um segmento. Tal segmento tem o tamanho do maior segmento suportado. 
+No in√≠cio, a janela de congestionamento tem o tamanho de um segmento. Tal segmento tem o tamanho do maior segmento suportado. 
 
-O primeiro segmento È enviado e ent„o È esperado seu reconhecimento.
+O primeiro segmento √© enviado e ent√£o √© esperado seu reconhecimento.
 
 *	Se o mesmo chegar antes que ocorra o timeout, o transmissor duplica o tamanho da janela de congestionamento e envia dois segmentos. 
-*	Se esses dois segmentos tambÈm forem reconhecidos antes de seus timeouts, o transmissor duplica novamente sua janela, enviando agora quatro segmentos.
+*	Se esses dois segmentos tamb√©m forem reconhecidos antes de seus timeouts, o transmissor duplica novamente sua janela, enviando agora quatro segmentos.
 
-Esse processo continua atÈ que:
+Esse processo continua at√© que:
 
 *	O tamanho da janela de congestionamento seja maior que o limiar, ou maior que o tamanho da janela do receptor;
-*	Ocorra algum timeouts antes da confirmaÁ„o.
+*	Ocorra algum timeouts antes da confirma√ß√£o.
 
-### Duas Fases dessa EvoluÁ„o
+### Duas Fases dessa Evolu√ß√£o
 
-A primeira fase, em que a janela de congestionamento cresce exponencialmente È congestionamento cresce exponencialmente È chamada de inicializaÁ„o lenta (slow start), pelo fato de comeÁar com um segmento - A taxa de transmiss„o comeÁa pequena, porÈm cresce muito rapidamente.
+A primeira fase, em que a janela de congestionamento cresce exponencialmente √© congestionamento cresce exponencialmente √© chamada de inicializa√ß√£o lenta (slow start), pelo fato de come√ßar com um segmento - A taxa de transmiss√£o come√ßa pequena, por√©m cresce muito rapidamente.
 
-Uma vez ultrapassado o limiar, e a janela do receptor ainda n„o seja um limitante o crescimento receptor ainda n„o seja um limitante, o crescimento da janela passa a ser linear. Essa segunda fase È chamada de prevenÁ„o de congestionamento (congestion avoidance). Sua duraÁ„o tambÈm depende da n„o ocorrÍncia timeouts, e da aceitaÁ„o do fluxo por parte do receptor.
+Uma vez ultrapassado o limiar, e a janela do receptor ainda n√£o seja um limitante o crescimento receptor ainda n√£o seja um limitante, o crescimento da janela passa a ser linear. Essa segunda fase √© chamada de preven√ß√£o de congestionamento (congestion avoidance). Sua dura√ß√£o tamb√©m depende da n√£o ocorr√™ncia timeouts, e da aceita√ß√£o do fluxo por parte do receptor.
 
 ### E quando ocorrer um problema?
 
-**Na ocorrÍncia de um timeout o TCP ir· configurar:**
+**Na ocorr√™ncia de um timeout o TCP ir√° configurar:**
 * O valor do limiar passa a ser a metade do tamanho atual da janela de congestionamento
 * O tamanho da janela de congestionamento volta a ser do tamanho de um segmento
 * O tamanho da janela de congestionamento volta a crescer exponencialmente
 
 **Caso ocorram 3 ACKs duplicados:** 
-* O valor do limiar È ajustado para metade tamanho atual da janela de congestionamento 
+* O valor do limiar √© ajustado para metade tamanho atual da janela de congestionamento 
 * O tamanho da janela de congestionamento passa igual ao valor do limiar (metade da janela de congestionamento atual) 
 * O tamanho da janela de congestionamento cresce linearmente
 
 #### Resumo
 
-Quando o tamanho da janela de congestionamento est· abaixo do limiar, seu crescimento È exponencial.
+Quando o tamanho da janela de congestionamento est√° abaixo do limiar, seu crescimento √© exponencial.
 
-Quando este tamanho est· acima do limiar, o crescimento È linear.
+Quando este tamanho est√° acima do limiar, o crescimento √© linear.
 
-Todas as vezes que ocorrer um timeout, o limiar È modificado para a metade do tamanho da janela e o tamanho da janela passa a ser 1.
+Todas as vezes que ocorrer um timeout, o limiar √© modificado para a metade do tamanho da janela e o tamanho da janela passa a ser 1.
 
-A rede n„o consegue entregar nenhum dos pacotes (ìcongestionamento pesadoî).
+A rede n√£o consegue entregar nenhum dos pacotes (‚Äúcongestionamento pesado‚Äù).
 
 Quando ocorrem ACKs repetidos a janela cai pela metade.
 
-A rede ainda È capaz de entregar alguns pacotes (ìcongestionamento leveî).
+A rede ainda √© capaz de entregar alguns pacotes (‚Äúcongestionamento leve‚Äù).


### PR DESCRIPTION
No resumo de camada de transporte de redes há um erro que faz com que os itens que deveriam estar aninhados dentro de UDP fiquem no mesmo nível que ele.