### PR TITLE
Adiciona botão de editar a página

### DIFF
--- a/_app/gatsby-config.js
+++ b/_app/gatsby-config.js
@@ -37,6 +37,7 @@ module.exports = {
         plugins: ['gatsby-remark-autolink-headers', 'gatsby-remark-tamburetei'],
       },
     },
+    'gatsby-plugin-catch-links',
     'gatsby-transformer-sharp',
     'gatsby-plugin-sharp',
     {

--- a/_app/package.json
+++ b/_app/package.json
@@ -23,6 +23,7 @@
     "classnames": "^2.2.6",
     "gatsby": "^2.15.29",
     "gatsby-image": "^2.2.24",
+    "gatsby-plugin-catch-links": "^2.1.13",
     "gatsby-plugin-google-fonts": "^1.0.1",
     "gatsby-plugin-manifest": "^2.2.20",
     "gatsby-plugin-react-helmet": "^3.1.10",

--- a/_app/src/components/Button.js
+++ b/_app/src/components/Button.js
@@ -23,7 +23,7 @@ const Button = ({
 
 Button.propTypes = {
   className: PropTypes.string,
-  children: PropTypes.element,
+  children: PropTypes.node,
   size: PropTypes.oneOf(['large', 'regular']),
   as: PropTypes.any,
 }

--- a/_app/src/components/Layout.js
+++ b/_app/src/components/Layout.js
@@ -54,7 +54,7 @@ const Layout = ({ className = '', children }) => {
 }
 
 Layout.propTypes = {
-  className: PropTypes.string.isRequired,
+  className: PropTypes.string,
   children: PropTypes.node.isRequired,
 }
 

--- a/_app/src/components/SEO.js
+++ b/_app/src/components/SEO.js
@@ -76,7 +76,7 @@ SEO.propTypes = {
   description: PropTypes.string,
   lang: PropTypes.string,
   meta: PropTypes.arrayOf(PropTypes.object),
-  title: PropTypes.string.isRequired,
+  title: PropTypes.string,
 }
 
 export default SEO

--- a/_app/src/pages/index.js
+++ b/_app/src/pages/index.js
@@ -32,7 +32,7 @@ const IndexPage = () => (
       <hr className={styles.divider} />
       <section className={styles.cardSection}>
         <div className={styles.card}>
-          <h3>Como funciona?</h3>
+          <h3 className={styles.cardTitle}>Como funciona?</h3>
           <p>
             Alunos do curso colaboram com várias informações como links úteis,
             resumos, provas e várias dicas. Esses arquivos ficam todos em nosso
@@ -48,7 +48,7 @@ const IndexPage = () => (
           </p>
         </div>
         <div className={styles.card}>
-          <h3>Regras</h3>
+          <h3 className={styles.cardTitle}>Regras</h3>
 
           <ol>
             <li>
@@ -66,7 +66,7 @@ const IndexPage = () => (
           </ol>
         </div>
         <div className={styles.card}>
-          <h3>Como contribuir</h3>
+          <h3 className={styles.cardTitle}>Como contribuir</h3>
           <p>
             Leia nosso <Link to="/contribuicao">guia de contribuição</Link>!
           </p>

--- a/_app/src/pages/index.module.css
+++ b/_app/src/pages/index.module.css
@@ -91,8 +91,8 @@
   }
 }
 
-.card h3 {
-  margin-top: 0;
+.cardTitle {
+  margin-bottom: 1.5rem;
 }
 
 .card ol {

--- a/_app/src/templates/Subject.js
+++ b/_app/src/templates/Subject.js
@@ -6,7 +6,7 @@ import SubjectLayout from '../components/SubjectLayout'
 import SEO from '../components/SEO'
 import styles from './Subject.module.scss'
 
-const BASE_PATH = 'https://github.com/OpenDevUFCG/Tamburetei/edit/master/'
+const BASE_PATH = 'https://github.com/OpenDevUFCG/Tamburetei/edit/master'
 
 const Subject = ({
   data: {

--- a/_app/src/templates/Subject.js
+++ b/_app/src/templates/Subject.js
@@ -6,15 +6,19 @@ import SubjectLayout from '../components/SubjectLayout'
 import SEO from '../components/SEO'
 import styles from './Subject.module.scss'
 
+const BASE_PATH = 'https://github.com/OpenDevUFCG/Tamburetei/edit/master/'
+
 const Subject = ({
   data: {
     markdownRemark: {
       html,
       frontmatter: { title },
+      parent: { relativePath },
     },
   },
   location,
 }) => {
+  const editUrl = `${BASE_PATH}/${relativePath}`
   return (
     <SubjectLayout location={location}>
       <SEO title={title} />
@@ -23,6 +27,14 @@ const Subject = ({
         className={styles.markdownRoot}
         dangerouslySetInnerHTML={{ __html: html }}
       />
+      <a
+        href={editUrl}
+        className="link"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Edite esta página
+      </a>
     </SubjectLayout>
   )
 }
@@ -30,6 +42,7 @@ const Subject = ({
 Subject.propTypes = {
   data: PropTypes.object,
   location: PropTypes.object,
+  pageContext: PropTypes.object,
 }
 
 export default Subject
@@ -48,6 +61,11 @@ export const pageQuery = graphql`
       html
       frontmatter {
         title
+      }
+      parent {
+        ... on File {
+          relativePath
+        }
       }
     }
   }

--- a/_app/yarn.lock
+++ b/_app/yarn.lock
@@ -729,6 +729,13 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
+"@babel/runtime@^7.6.3":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.6.3.tgz#935122c74c73d2240cafd32ddb5fc2a6cd35cf1f"
+  integrity sha512-kq6anf9JGjW8Nt5rYfEuGRaEAaH1mkv3Bbu6rYvLOpPh/RusSJXuKPEAoZ7L7gybZkchE8+NV5g9vKF4AGAtsA==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
 "@babel/template@^7.1.0", "@babel/template@^7.4.4", "@babel/template@^7.6.0":
   version "7.6.0"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.6.0.tgz#7f0159c7f5012230dad64cca42ec9bdb5c9536e6"
@@ -5408,6 +5415,14 @@ gatsby-page-utils@^0.0.24:
     lodash "^4.17.15"
     micromatch "^3.1.10"
     slash "^3.0.0"
+
+gatsby-plugin-catch-links@^2.1.13:
+  version "2.1.13"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-catch-links/-/gatsby-plugin-catch-links-2.1.13.tgz#b7c72d3c2ca9822ab7a4a4d35f67b1134334d82b"
+  integrity sha512-8rDkszTXF7mR/rFT0ItqoYfr9Hgx7sUFA0tRGeBbcAM1tpuXssvlTbxWzH8pph/PTQtOvDv1dPCGBntfnr1Waw==
+  dependencies:
+    "@babel/runtime" "^7.6.3"
+    escape-string-regexp "^1.0.5"
 
 gatsby-plugin-google-fonts@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Este PR adiciona um botão (na verdade um link) para editar a página atual no GitHub, deixando mais fácil para alguém corrigir algum problema visto.

Eu também adicionei o plugin `gatsby-plugin-catch-links`, que atualiza todos os links que são para páginas internas para usar o redirect do `gatsby-link`, melhorando a experiência com o SPA. Antes, esses links que eram para páginas internas (gerados pelo plugin do markdown) eram tratados como links normais pelo browser, e quando o usuário clicava neles o browser fazia a requisição da página inteira, o que era bem demorado.

- [X] Minha contribuição respeita o [código de conduta](https://github.com/OpenDevUFCG/Tamburetei/blob/master/CODE_OF_CONDUCT.md) do repositório.
- [X] Minha contribuição respeita as [restrições de upload](https://github.com/OpenDevUFCG/Tamburetei/wiki/Restrições-de-Upload) do repositório.
