### PR TITLE
adiciona links de materiais para visualização de dados

### DIFF
--- a/visu/linksUteis.md
+++ b/visu/linksUteis.md
@@ -18,7 +18,11 @@ Uma lista de links que irão auxiliá-lo no estudo da disciplina.
 
 - [Galeria D3](https://github.com/d3/d3/wiki/Gallery)
 - [Guia de Visualizações com exemplos de aplicação](https://datavizcatalogue.com/index.html)
+- [Guia de visualizações mais apropriadas para seus dados](https://www.data-to-viz.com/)
+- [Manual: IBM - Design Language](https://www.ibm.com/design/v1/language/experience/data-visualization/)
 
 ## Cores
 
 - [Guia de cores para mapas](http://colorbrewer2.org/#type=sequential&scheme=BuGn&n=3)
+- [Gerador de paletas](https://coolors.co/)
+


### PR DESCRIPTION
Fix: #371 

Adicionei links sugeridos como materiais de apoio para a disciplina
- **From data to Viz:** ferramenta que sugere a melhor visualização para seu dado
- **Manual do IBM:** a empresa criou materiais de design para sua equipe de engenheiros e acabou disponibilizando para a comunidade também \o/
- **Coolors:** gera, sugere e deixa o usuário criar paletas de cores, adaptando-as para cobrir o maior campo de visão do ser humano

- [X] Minha contribuição respeita o [código de conduta](https://github.com/OpenDevUFCG/Tamburetei/blob/master/CODE_OF_CONDUCT.md) do repositório.
- [X] Minha contribuição respeita as [restrições de upload](https://github.com/OpenDevUFCG/Tamburetei/wiki/Restrições-de-Upload) do repositório.
