### PR TITLE
adiciona link para tradutor RISC-V

### DIFF
--- a/loac/linksUteis.md
+++ b/loac/linksUteis.md
@@ -22,3 +22,4 @@ Uma lista de links que irão auxiliá-lo no estudo da disciplina.
 
 - [Simulador de FPGA](https://github.com/Icaro-Lima/LabarcFPGASimulatorDesktop)
 - [Simulador de circuitos elétricos](https://www.tinkercad.com)
+- [Tradutor de binário para RISC-V assembly](https://github.com/pserey/risc-v-binary-translator)


### PR DESCRIPTION
Opa gente! Adicionei o link em links úteis de LOAC para o repositório de um CLI em python que traduz instruções em binário ou hexadecimal para assembly em RISC-V. Fiz esse códigozinho no período que cursei a cadeira e foi bem útil para algumas atividades e estudos.